### PR TITLE
[FIX ] use $(HOME) instead of ~ in Makefile (main)

### DIFF
--- a/pkg/formula/tpl/tplgo/tpl_go.go
+++ b/pkg/formula/tpl/tplgo/tpl_go.go
@@ -151,22 +151,22 @@ test-local:
 ifneq ("$(FORM)", "")
 	@echo "Using form true: "  $(FORM_TO_UPPER)
 	$(MAKE) bin FORMULAS=$(FORM)
-	mkdir -p ~/.rit/formulas
-	rm -rf ~/.rit/formulas/$(FORM)
+	mkdir -p $(HOME)/.rit/formulas
+	rm -rf $(HOME)/.rit/formulas/$(FORM)
 	./unzip-bin-configs.sh
-	cp -r formulas/* ~/.rit/formulas
+	cp -r formulas/* $(HOME)/.rit/formulas
 	rm -rf formulas
 else
 	@echo "Use make test-local form=NAME_FORMULA for specific formula."
 	@echo "form false: ALL FORMULAS"
 	$(MAKE) bin
-	rm -rf ~/.rit/formulas
+	rm -rf $(HOME)/.rit/formulas
 	./unzip-bin-configs.sh
-	mv formulas ~/.rit
+	mv formulas $(HOME)/.rit
 endif
-	mkdir -p ~/.rit/repo/local
-	rm -rf ~/.rit/repo/local/tree.json
-	cp tree/tree.json  ~/.rit/repo/local/tree.json
+	mkdir -p $(HOME)/.rit/repo/local
+	rm -rf $(HOME)/.rit/repo/local/tree.json
+	cp tree/tree.json  $(HOME)/.rit/repo/local/tree.json
 `
 	TemplatePkg = `package {{nameModule}}
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/v/doc-english/community

Please provide the following information:
-->

**- What I did**

- Updating the makefile (main) template for the `rit create formula` command as the ~ wasn't working on Windows.

**- How I did it**

- Used $(HOME) instead of ~

**- How to verify it**

- Testing the `rit create formula` command on windows

**- Description for the changelog**

- Updating Makefile (main) template for windows users
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
