### PR TITLE
[Fix] Remove special char in prompt

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -66,7 +66,7 @@ func newInitCmd(stdinFunc, promptFunc CommandRunnerFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Init rit",
-		Long:  "Initiliaze rit configuration",
+		Long:  "Initialize rit configuration",
 		RunE:  RunFuncE(stdinFunc, promptFunc),
 	}
 	cmd.LocalFlags()

--- a/pkg/prompt/bool.go
+++ b/pkg/prompt/bool.go
@@ -20,6 +20,7 @@ func NewInputBool() inputBool {
 func (inputBool) Bool(name string, items []string) (bool, error) {
 	prompt := promptui.Select{
 		Items:     items,
+		Pointer: promptui.PipeCursor,
 		Templates: defaultSelectTemplate(name),
 	}
 	_, result, err := prompt.Run()

--- a/pkg/prompt/email.go
+++ b/pkg/prompt/email.go
@@ -19,6 +19,7 @@ func NewInputEmail() inputEmail {
 func (inputEmail) Email(name string) (string, error) {
 	prompt := promptui.Prompt{
 		Label:     name,
+		Pointer: promptui.PipeCursor,
 		Validate:  validator.IsValidEmail,
 		Templates: defaultTemplate(),
 	}

--- a/pkg/prompt/int.go
+++ b/pkg/prompt/int.go
@@ -19,6 +19,7 @@ func NewInputInt() inputInt {
 func (inputInt) Int(name string) (int64, error) {
 	prompt := promptui.Prompt{
 		Label:     name,
+		Pointer: promptui.PipeCursor,
 		Validate:  validateIntegerNumberInput,
 		Templates: defaultTemplate(),
 	}

--- a/pkg/prompt/list.go
+++ b/pkg/prompt/list.go
@@ -16,6 +16,7 @@ func NewInputList() inputList {
 func (inputList) List(name string, items []string) (string, error) {
 	prompt := promptui.Select{
 		Items:     items,
+		Pointer: promptui.PipeCursor,
 		Templates: defaultSelectTemplate(name),
 	}
 	_, result, err := prompt.Run()

--- a/pkg/prompt/password.go
+++ b/pkg/prompt/password.go
@@ -21,6 +21,7 @@ func NewInputPassword() inputPassword {
 func (inputPassword) Password(label string) (string, error) {
 	prompt := promptui.Prompt{
 		Label:     label,
+		Pointer: promptui.PipeCursor,
 		Mask:      '*',
 		Validate:  validateEmptyInput,
 		Templates: defaultTemplate(),

--- a/pkg/prompt/text.go
+++ b/pkg/prompt/text.go
@@ -19,12 +19,14 @@ func (inputText) Text(name string, required bool) (string, error) {
 	if required {
 		prompt = promptui.Prompt{
 			Label:     name,
+			Pointer: promptui.PipeCursor,
 			Validate:  validateEmptyInput,
 			Templates: defaultTemplate(),
 		}
 	} else {
 		prompt = promptui.Prompt{
 			Label:     name,
+			Pointer: promptui.PipeCursor,
 			Templates: defaultTemplate(),
 		}
 	}

--- a/pkg/prompt/url.go
+++ b/pkg/prompt/url.go
@@ -19,6 +19,7 @@ func NewInputURL() inputURL {
 func (inputURL) URL(name, defaultValue string) (string, error) {
 	prompt := promptui.Prompt{
 		Label:     name,
+		Pointer: promptui.PipeCursor,
 		Default:   defaultValue,
 		Validate:  validator.IsValidURL,
 		Templates: defaultTemplate(),


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**

I removed special char in prompt
![image](https://user-images.githubusercontent.com/17505818/83459991-bf6f7580-a43b-11ea-9d8e-6acacd2cebd6.png)

**- How I did it**

I added the Pointer config in Ritchie prompts