### PR TITLE
[FIX] env runner formula

### DIFF
--- a/pkg/formula/runner.go
+++ b/pkg/formula/runner.go
@@ -19,8 +19,8 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 	"github.com/ZupIT/ritchie-cli/pkg/file/fileutil"
 	"github.com/ZupIT/ritchie-cli/pkg/prompt"
-	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 	"github.com/ZupIT/ritchie-cli/pkg/session"
+	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 )
 
 const (
@@ -122,8 +122,9 @@ func (d DefaultRunner) Run(def Definition, inputType api.TermInputType) error {
 		return err
 	}
 	bFilePath = def.BinFilePath(tBDir, bName)
-
 	cmd := exec.Command(bFilePath)
+
+	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Added cmd.Env = os.Environ() in runner.go

**- How I did it**
Added cmd.Env = os.Environ() in runner.go

**- How to verify it**
Tests with enerlioJr and Guillaume

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Pass env when running formula