### PR TITLE
[FIX] Adding trapdoor to error while removing branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ functional-test-team:
 rebase-nightly:
 	git config --global user.email "$(GIT_EMAIL)"
 	git config --global user.name "$(GIT_NAME)"
-	git push $(GIT_REMOTE) --delete nightly
+	git push $(GIT_REMOTE) --delete nightly | true
 	git checkout -b nightly
 	git reset --hard master
 	git add .


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
I added code that make sure the pipeline continues even if the remote branch doesn't exist

**- How I did it**
By changing the Makefile

**- How to verify it**
See if the error stops occurring from now on

**- Description for the changelog**
Fix for nightly releases
