### PR TITLE
change run-tests and scripts to windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,2 @@
+go build -o ./dist/windows/team/rit.exe -v ./cmd/team/main.go
+go build -o ./dist/windows/single/rit.exe -v ./cmd/single/main.go

--- a/rit-single.cmd
+++ b/rit-single.cmd
@@ -1,0 +1,1 @@
+start /b /w dist/windows/single/rit.exe %*

--- a/rit-team.cmd
+++ b/rit-team.cmd
@@ -1,0 +1,1 @@
+start /b /w dist/windows/team/rit.exe %*

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,7 +5,7 @@ docker-compose up -d
 export REPO_URL=http://localhost:8882/formulas
 
 mkdir -p bin
-go test -v -short -coverprofile=bin/cov.out $(go list ./pkg/... | grep -v vendor/)
+go test -v -failfast -short -coverprofile=bin/cov.out $(go list ./pkg/... | grep -v vendor/) || exit 1
 go tool cover -func=bin/cov.out
 
 docker-compose down


### PR DESCRIPTION
**- What I did**
change run-tests.sh to exit 1 if some test fail
add scripts to build and run on windows

**- How I did it**
change run-tests.sh to exit 1 if some test fail
add scripts to build and run on windows

**- How to verify it**
on windows: 
build.cmd
rit-team.cmd --version
rit-single.cmd --version

**- Description for the changelog**
add scripts to help build on windows
-->
