### PR TITLE
Clean formulas command

### DIFF
--- a/cmd/single/main.go
+++ b/cmd/single/main.go
@@ -116,6 +116,7 @@ func buildCommands() *cobra.Command {
 	addCmd := cmd.NewAddCmd()
 	createCmd := cmd.NewCreateCmd()
 	deleteCmd := cmd.NewDeleteCmd()
+	cleanCmd := cmd.NewCleanCmd()
 	initCmd := cmd.NewSingleInitCmd(inputPassword, passphraseManager, repoLoader)
 	listCmd := cmd.NewListCmd()
 	setCmd := cmd.NewSetCmd()
@@ -146,11 +147,13 @@ func buildCommands() *cobra.Command {
 
 	createFormulaCmd := cmd.NewCreateFormulaCmd(userHomeDir, createBuilder, formulaWorkspace, inputText, inputTextValidator, inputList)
 	buildFormulaCmd := cmd.NewBuildFormulaCmd(userHomeDir, formulaBuilder, formulaWorkspace, watchManager, dirManager, inputText, inputList)
+	cleanFormulasCmd := cmd.NewCleanFormulasCmd()
 
 	autocompleteCmd.AddCommand(autocompleteZsh, autocompleteBash, autocompleteFish, autocompletePowerShell)
 	addCmd.AddCommand(addRepoCmd)
 	createCmd.AddCommand(createFormulaCmd)
 	deleteCmd.AddCommand(deleteRepoCmd, deleteCtxCmd)
+	cleanCmd.AddCommand(cleanFormulasCmd)
 	listCmd.AddCommand(listRepoCmd)
 	setCmd.AddCommand(setCredentialCmd, setCtxCmd)
 	showCmd.AddCommand(showCtxCmd)
@@ -170,6 +173,7 @@ func buildCommands() *cobra.Command {
 				autocompleteCmd,
 				createCmd,
 				deleteCmd,
+				cleanCmd,
 				initCmd,
 				listCmd,
 				setCmd,

--- a/cmd/team/main.go
+++ b/cmd/team/main.go
@@ -140,6 +140,7 @@ func buildCommands() *cobra.Command {
 	addCmd := cmd.NewAddCmd()
 	createCmd := cmd.NewCreateCmd()
 	deleteCmd := cmd.NewDeleteCmd()
+	cleanCmd := cmd.NewCleanCmd()
 	initCmd := cmd.NewTeamInitCmd(
 		inputText,
 		inputPassword,
@@ -182,11 +183,13 @@ func buildCommands() *cobra.Command {
 
 	createFormulaCmd := cmd.NewCreateFormulaCmd(userHomeDir, createBuilder, formulaWorkspace, inputText, inputTextValidator, inputList)
 	buildFormulaCmd := cmd.NewBuildFormulaCmd(userHomeDir, formulaBuilder, formulaWorkspace, watchManager, dirManager, inputText, inputList)
+	cleanFormulasCmd := cmd.NewCleanFormulasCmd()
 
 	autocompleteCmd.AddCommand(autocompleteZsh, autocompleteBash, autocompleteFish, autocompletePowerShell)
 	addCmd.AddCommand(addRepoCmd)
 	createCmd.AddCommand(createFormulaCmd)
 	deleteCmd.AddCommand(deleteRepoCmd, deleteCtxCmd)
+	cleanCmd.AddCommand(cleanFormulasCmd)
 	listCmd.AddCommand(listRepoCmd)
 	setCmd.AddCommand(setCredentialCmd, setCtxCmd)
 	showCmd.AddCommand(showCtxCmd)
@@ -206,6 +209,7 @@ func buildCommands() *cobra.Command {
 				autocompleteCmd,
 				createCmd,
 				deleteCmd,
+				cleanCmd,
 				initCmd,
 				listCmd,
 				loginCmd,

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -4,7 +4,7 @@ import (
 "github.com/spf13/cobra"
 )
 
-var descCleanLong = `
+const descCleanLong = `
 This command consists of multiple subcommands to interact with ritchie.
 
 It can be used to clean formulas from your current ritchie build

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+"github.com/spf13/cobra"
+)
+
+var descCleanLong = `
+This command consists of multiple subcommands to interact with ritchie.
+
+It can be used to clean formulas from your current ritchie build
+`
+
+// NewCleanCmd create a new clean instance
+func NewCleanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clean SUBCOMMAND",
+		Short: "Clean properties",
+		Long:  descCleanLong,
+	}
+}
+

--- a/pkg/cmd/clean_formulas.go
+++ b/pkg/cmd/clean_formulas.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ZupIT/ritchie-cli/pkg/api"
+	"github.com/ZupIT/ritchie-cli/pkg/stdin"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ZupIT/ritchie-cli/pkg/prompt"
+)
+
+// cleanFormulasCmd type for clean formulas command
+type cleanFormulasCmd struct {
+	prompt.InputBool
+}
+
+// cleanFormulas type for stdin json decoder
+type cleanFormulasStdin struct {
+	Confirm bool `json:"confirm"`
+}
+
+// NewCleanFormulasCmd cleans formulas in .rit/formulas file
+func NewCleanFormulasCmd() *cobra.Command {
+	cleanCmd := &cleanFormulasCmd{
+		prompt.NewSurveyBool(),
+	}
+
+	cmd := &cobra.Command{
+		Use:     "formulas",
+		Short:   "Cleans all downloaded formulas",
+		Example: "rit clean formulas",
+		RunE:    RunFuncE(cleanCmd.runStdin(), cleanCmd.runPrompt()),
+	}
+
+	cmd.LocalFlags()
+
+	return cmd
+}
+
+func (cleanFormula cleanFormulasCmd) runPrompt() CommandRunnerFunc {
+	return func(cmd *cobra.Command, args []string) error {
+
+		choice, _ := cleanFormula.Bool(
+			fmt.Sprint("Are you sure you want to clean all your downloaded formulas?"),
+			[]string{"yes", "no"},
+		)
+		if !choice {
+			fmt.Println("Operation cancelled")
+			return nil
+		}
+
+		formulasDirectory := fmt.Sprintf("%s/formulas", api.RitchieHomeDir())
+		if err := os.RemoveAll(formulasDirectory); err != nil {
+			return err
+		}
+
+		prompt.Success(fmt.Sprint("Your formulas folder has been cleaned!\n"))
+		return nil
+	}
+}
+
+func (cleanFormula cleanFormulasCmd) runStdin() CommandRunnerFunc {
+	return func(cmd *cobra.Command, args []string) error {
+
+		stdinArgs := cleanFormulasStdin{}
+
+		err := stdin.ReadJson(os.Stdin, &stdinArgs)
+		if err != nil {
+			prompt.Error(stdin.MsgInvalidInput)
+			return err
+		}
+
+		if !stdinArgs.Confirm {
+			fmt.Println("Operation cancelled")
+			return nil
+		}
+
+		formulasDirectory := fmt.Sprintf("%s/formulas", api.RitchieHomeDir())
+		if err := os.RemoveAll(formulasDirectory); err != nil {
+			return err
+		}
+
+		prompt.Success(fmt.Sprint("Your formulas folder has been cleaned!\n"))
+		return nil
+	}
+}

--- a/pkg/cmd/clean_formulas_test.go
+++ b/pkg/cmd/clean_formulas_test.go
@@ -20,8 +20,17 @@ func TestNewCleanFormulasCmd(t *testing.T) {
 }
 
 func TestNewCleanFormulasCmdStdin(t *testing.T) {
+	t.Run("confirm", func(t *testing.T) {
+		runStdinCommand(t, `{"confirm": true}`)
+	})
 
-	tmpfile, oldStdin, err := stdin.WriteToStdin(`{"confirm": true}`)
+	t.Run("not confirm", func(t *testing.T) {
+		runStdinCommand(t, `{"confirm": false}`)
+	})
+}
+
+func runStdinCommand(t *testing.T, content string) {
+	tmpfile, oldStdin, err := stdin.WriteToStdin(content)
 	defer os.Remove(tmpfile.Name())
 	defer func() { os.Stdin = oldStdin }()
 	if err != nil {

--- a/pkg/cmd/clean_formulas_test.go
+++ b/pkg/cmd/clean_formulas_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ZupIT/ritchie-cli/pkg/stdin"
+)
+
+func TestNewCleanFormulasCmd(t *testing.T) {
+	cmd := NewCleanFormulasCmd()
+	cmd.PersistentFlags().Bool("stdin", false, "input by stdin")
+	if cmd == nil {
+		t.Errorf("NewCleanFormulasCmd got %v", cmd)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("%s = %v, want %v", cmd.Use, err, nil)
+	}
+}
+
+func TestNewCleanFormulasCmdStdin(t *testing.T) {
+
+	tmpfile, oldStdin, err := stdin.WriteToStdin(`{"confirm": true}`)
+	defer os.Remove(tmpfile.Name())
+	defer func() { os.Stdin = oldStdin }()
+	if err != nil {
+		t.Errorf("TestNewCleanFormulasCmdStdin got error %v", err)
+	}
+
+	cmd := NewCleanFormulasCmd()
+	cmd.PersistentFlags().Bool("stdin", true, "input by stdin")
+	if cmd == nil {
+		t.Errorf("NewCleanFormulasCmd got %v", cmd)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("%s = %v, want %v", cmd.Use, err, nil)
+	}
+}
+

--- a/pkg/cmd/clean_test.go
+++ b/pkg/cmd/clean_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+"testing"
+)
+
+func TestNewCleanCmd(t *testing.T) {
+	cmd := NewCleanCmd()
+	if cmd == nil {
+		t.Errorf("NewCleanCmd got %v", cmd)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("%s = %v, want %v", cmd.Use, err, nil)
+	}
+}
+

--- a/pkg/stdin/stdin.go
+++ b/pkg/stdin/stdin.go
@@ -3,6 +3,8 @@ package stdin
 import (
 	"encoding/json"
 	"io"
+	"io/ioutil"
+	"os"
 )
 
 const (
@@ -12,4 +14,34 @@ const (
 // ReadJson reads the json from stdin inputs
 func ReadJson(reader io.Reader, v interface{}) error {
 	return json.NewDecoder(reader).Decode(v)
+}
+
+// This function aims to facilitate stdin manipulations especially on tests
+// inputs:
+// 		content string: the string content for the stdin
+// outputs:
+//		tmpfile File: the tmp file read by stdin
+// 		oldstdin File: the original stdin being overwritten
+// NOTICE: do not forget to remove the tmpfile and restore the original stdin, use the commands
+// 		defer func() { os.Stdin = oldStdin }()
+// 		defer os.Remove(tmpfile.Name())
+func WriteToStdin(content string) (tmpfile *os.File, oldStdin *os.File, error error) {
+	fileContent := []byte(content)
+	tmpfile, err := ioutil.TempFile("", "stdin")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, err := tmpfile.Write(fileContent); err != nil {
+		return nil, nil, err
+	}
+
+	if _, err := tmpfile.Seek(0, 0); err != nil {
+		return nil, nil, err
+	}
+
+	oldstdin := os.Stdin
+	os.Stdin = tmpfile
+
+	return tmpfile, oldstdin, nil
 }

--- a/pkg/stdin/stdin_test.go
+++ b/pkg/stdin/stdin_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
 )
 
@@ -34,5 +35,14 @@ func TestReadJson(t *testing.T) {
 	// Assert the decoder result is the initial message
 	if msg != tr.Test {
 		t.Errorf("Expected : %v but got %v", msg, tr.Test)
+	}
+}
+
+func TestWriteToStdin(t *testing.T) {
+	tmpfile, oldStdin, err := WriteToStdin(`{"confirm": true}`)
+	defer os.Remove(tmpfile.Name())
+	defer func() { os.Stdin = oldStdin }()
+	if err != nil {
+		t.Errorf("TestNewCleanFormulasCmdStdin got error %v", err)
 	}
 }


### PR DESCRIPTION
**- What I did**

* added `rit clean formulas` command that cleans `~/.rit/formulas` folder

* Created a utilitary method in `stdin` to overwrite the `os.Stdin` and allow for stdin tests

* Proposed a stdin test for increased command coverage

**- How to verify it**
run `rit clean formulas` and verify your saved formulas

**- Description for the changelog**
added `rit clean formulas` command to cleanup downloaded formulas
