### PR TITLE
adding powershell and fish and modifying helpers

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,8 @@ var (
 		{Parent: "root", Usage: "completion"},
 		{Parent: "root_completion", Usage: "bash"},
 		{Parent: "root_completion", Usage: "zsh"},
+		{Parent: "root_completion", Usage: "fish"},
+		{Parent: "root_completion", Usage: "powershell"},
 		{Parent: "root", Usage: "delete"},
 		{Parent: "root_delete", Usage: "context"},
 		{Parent: "root_delete", Usage: "repo"},

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -40,9 +40,19 @@ func NewAutocompleteZsh(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:     zsh.String(),
-		Short:   "Add zsh autocomplete for terminal",
-		Long:    "Add zsh autocomplete for terminal",
-		Example: "rit completion zsh",
+		Short:   "Add zsh autocomplete for terminal, --help to know how to use",
+		Long:    `
+Add bash autocomplete for terminal
+Only works if zsh auto completion is installed.
+
+To test run: 
+ $ rit completion zsh | source
+
+To install run: 
+ $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion zsh > ~/.rit_completion" >> ~/.zshrc
+
+`,
+		Example: "rit completion zsh | source",
 		RunE:    a.runFunc(),
 	}
 }
@@ -53,9 +63,19 @@ func NewAutocompleteBash(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:     bash.String(),
-		Short:   "Add bash autocomplete for terminal",
-		Long:    "Add bash autocomplete for terminal",
-		Example: "rit completion bash",
+		Short:   "Add bash autocomplete for terminal, --help to know how to use",
+		Long:    `
+Add bash autocomplete for terminal
+Only works if bash auto completion is installed.
+
+To test run: 
+ $ rit completion bash | source
+
+To install run: 
+ $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion bash > ~/.rit_completion" >> ~/.bashrc
+
+`,
+		Example: "rit completion bash | source",
 		RunE:    a.runFunc(),
 	}
 }
@@ -66,7 +86,7 @@ func NewAutocompleteFish(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:   fish.String(),
-		Short: "Add fish autocomplete for terminal --help to know how to use",
+		Short: "Add fish autocomplete for terminal, --help to know how to use",
 		Long: `
 Add fish autocomplete for terminal
 Only fish >= version 3.X is supported (fish 2.X is not supported)
@@ -89,7 +109,7 @@ func NewAutocompletePowerShell(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:   powerShell.String(),
-		Short: "Add powerShell autocomplete for terminal --help to know how to use",
+		Short: "Add powerShell autocomplete for terminal, --help to know how to use",
 		Long: `
 Add powerShell autocomplete for terminal
 Only powerShell >= version 5.X is supported

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -42,7 +42,7 @@ func NewAutocompleteZsh(g autocomplete.Generator) *cobra.Command {
 		Use:     zsh.String(),
 		Short:   "Add zsh autocomplete for terminal, --help to know how to use",
 		Long:    `
-Add bash autocomplete for terminal
+Add zsh autocomplete for terminal
 Only works if zsh auto completion is installed.
 
 To test run: 
@@ -50,6 +50,7 @@ To test run:
 
 To install run: 
  $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion zsh > ~/.rit_completion" >> ~/.zshrc
+ $ echo "source ~/.rit_completion" >> ~/.zshrc
 
 `,
 		Example: "rit completion zsh | source",
@@ -73,6 +74,7 @@ To test run:
 
 To install run: 
  $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion bash > ~/.rit_completion" >> ~/.bashrc
+ $ echo "source ~/.rit_completion" >> ~/.bashrc
 
 `,
 		Example: "rit completion bash | source",


### PR DESCRIPTION
**- What I did**
Added missing helpers and autocomplete

**- How to verify it**
See if `rit completion` reflects:
```
Add autocomplete for terminal, Available for (zsh, bash, fish, powershell).

Examples:
rit completion zsh

Available Commands:
  bash        Add bash autocomplete for terminal, --help to know how to use
  fish        Add fish autocomplete for terminal, --help to know how to use
  powershell  Add powerShell autocomplete for terminal, --help to know how to use
  zsh         Add zsh autocomplete for terminal, --help to know how to use

```
