### PR TITLE
[Fix] Credential AWS Provider Default

### DIFF
--- a/pkg/credential/credsingle/settings.go
+++ b/pkg/credential/credsingle/settings.go
@@ -69,12 +69,12 @@ func NewDefaultCredentials() credential.Fields {
 	}
 
 	var accessKeyId = credential.Field{
-		Name: "accessKeyId",
+		Name: "accesskeyid",
 		Type: "plain text",
 	}
 
 	var secretAccessKey = credential.Field{
-		Name: "secretAccessKey",
+		Name: "secretaccesskey",
 		Type: "secret",
 	}
 


### PR DESCRIPTION
**- What I did**
Fixed acccesKeyId and secretAcessKeyId for lowercase in the aws credential provider.

**- How to verify it**
Use any formula with aws credential provider

**- Description for the changelog**
Fixed name inputs aws credential  provider

