### PR TITLE
change help of completion as same as master branch

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,6 +18,8 @@ var (
 		{Parent: "root", Usage: "completion"},
 		{Parent: "root_completion", Usage: "bash"},
 		{Parent: "root_completion", Usage: "zsh"},
+		{Parent: "root_completion", Usage: "fish"},
+		{Parent: "root_completion", Usage: "powershell"},
 		{Parent: "root", Usage: "delete"},
 		{Parent: "root_delete", Usage: "context"},
 		{Parent: "root_delete", Usage: "repo"},

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -40,10 +40,21 @@ func NewAutocompleteZsh(g autocomplete.Generator) *cobra.Command {
 	a := &autocompleteCmd{g}
 
 	return &cobra.Command{
-		Use:     zsh.String(),
-		Short:   "Add zsh autocomplete for terminal",
-		Long:    "Add zsh autocomplete for terminal",
-		Example: "rit completion zsh",
+		Use:   zsh.String(),
+		Short: "Add zsh autocomplete for terminal, --help to know how to use",
+		Long: `
+Add zsh autocomplete for terminal
+Only works if zsh auto completion is installed.
+
+To test run: 
+ $ rit completion zsh | source
+
+To install run: 
+ $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion zsh > ~/.rit_completion" >> ~/.zshrc
+ $ echo "source ~/.rit_completion" >> ~/.zshrc
+
+`,
+		Example: "rit completion zsh | source",
 		RunE:    a.runFunc(),
 	}
 }
@@ -53,10 +64,21 @@ func NewAutocompleteBash(g autocomplete.Generator) *cobra.Command {
 	a := &autocompleteCmd{g}
 
 	return &cobra.Command{
-		Use:     bash.String(),
-		Short:   "Add bash autocomplete for terminal",
-		Long:    "Add bash autocomplete for terminal",
-		Example: "rit completion bash",
+		Use:   bash.String(),
+		Short: "Add bash autocomplete for terminal, --help to know how to use",
+		Long: `
+Add bash autocomplete for terminal
+Only works if bash auto completion is installed.
+
+To test run: 
+ $ rit completion bash | source
+
+To install run: 
+ $ echo "[[ -r "/usr/local/bin/rit" ]] && rit completion bash > ~/.rit_completion" >> ~/.bashrc
+ $ echo "source ~/.rit_completion" >> ~/.bashrc
+
+`,
+		Example: "rit completion bash | source",
 		RunE:    a.runFunc(),
 	}
 }
@@ -67,7 +89,7 @@ func NewAutocompleteFish(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:   fish.String(),
-		Short: "Add fish autocomplete for terminal --help to know how to use",
+		Short: "Add fish autocomplete for terminal, --help to know how to use",
 		Long: `
 Add fish autocomplete for terminal
 Only fish >= version 3.X is supported (fish 2.X is not supported)
@@ -90,7 +112,7 @@ func NewAutocompletePowerShell(g autocomplete.Generator) *cobra.Command {
 
 	return &cobra.Command{
 		Use:   powerShell.String(),
-		Short: "Add powerShell autocomplete for terminal --help to know how to use",
+		Short: "Add powerShell autocomplete for terminal, --help to know how to use",
 		Long: `
 Add powerShell autocomplete for terminal
 Only powerShell >= version 5.X is supported


### PR DESCRIPTION
**- What I did**
change completion help msg to same as master branch

**- How to verify it**
```bash
rit completion bash --help
rit completion zsh --help
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
