### PR TITLE
Change build formulas behavior

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,7 +94,7 @@ func buildCommands() *cobra.Command {
 	tutorialFindSetter := rtutorial.NewFindSetter(ritchieHomeDir, tutorialFinder, tutorialSetter)
 
 	formBuildMake := builder.NewBuildMake()
-	formBuildBat := builder.NewBuildBat()
+	formBuildBat := builder.NewBuildBat(fileManager)
 	formBuildDocker := builder.NewBuildDocker()
 	formulaLocalBuilder := builder.NewBuildLocal(ritchieHomeDir, dirManager, fileManager, treeGen)
 

--- a/pkg/cmd/build_formula.go
+++ b/pkg/cmd/build_formula.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/kaduartur/go-cli-spinner/pkg/spinner"
@@ -19,7 +19,7 @@ import (
 const (
 	newWorkspace = "Type new formula workspace?"
 	dirPattern   = "%s/%s"
-	treeDir      = "tree"
+	docsDir      = "docs"
 	srcDir       = "src"
 )
 
@@ -74,7 +74,7 @@ func (b buildFormulaCmd) runFunc() CommandRunnerFunc {
 			return err
 		}
 
-		defaultWorkspace := path.Join(b.userHomeDir, formula.DefaultWorkspaceDir)
+		defaultWorkspace := filepath.Join(b.userHomeDir, formula.DefaultWorkspaceDir)
 		if b.directory.Exists(defaultWorkspace) {
 			workspaces[formula.DefaultWorkspaceName] = defaultWorkspace
 		}
@@ -142,7 +142,7 @@ func (b buildFormulaCmd) readFormulas(dir string) (string, error) {
 		return "", err
 	}
 
-	dirs = sliceutil.Remove(dirs, treeDir)
+	dirs = sliceutil.Remove(dirs, docsDir)
 
 	if isFormula(dirs) {
 		return dir, nil

--- a/pkg/cmd/create_formula.go
+++ b/pkg/cmd/create_formula.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -102,7 +103,7 @@ func (c createFormulaCmd) runPrompt() CommandRunnerFunc {
 			return err
 		}
 
-		defaultWorkspace := path.Join(c.homeDir, formula.DefaultWorkspaceDir)
+		defaultWorkspace := filepath.Join(c.homeDir, formula.DefaultWorkspaceDir)
 		workspaces[formula.DefaultWorkspaceName] = defaultWorkspace
 
 		wspace, err := FormulaWorkspaceInput(workspaces, c.inList, c.inText)

--- a/pkg/cmd/create_formula.go
+++ b/pkg/cmd/create_formula.go
@@ -160,8 +160,6 @@ func (c createFormulaCmd) create(cf formula.Create, workspacePath, formulaPath s
 		return
 	}
 
-	createSuccess(s, cf.Lang)
-
 	if err := c.formula.Build(workspacePath, formulaPath); err != nil {
 		err := prompt.NewError(err.Error())
 		s.Error(err)
@@ -173,6 +171,7 @@ func (c createFormulaCmd) create(cf formula.Create, workspacePath, formulaPath s
 		s.Error(err)
 		return
 	}
+	createSuccess(s, cf.Lang)
 	buildSuccess(formulaPath, cf.FormulaCmd, tutorialHolder.Current)
 }
 

--- a/pkg/cmd/formula_test.go
+++ b/pkg/cmd/formula_test.go
@@ -49,7 +49,7 @@ func TestFormulaCommand_Add(t *testing.T) {
 		},
 		{
 			name: "success docker",
-			args: []string{"mock", "test", "--local"},
+			args: []string{"mock", "test", "--docker"},
 		},
 		{
 			name: "success stdin",

--- a/pkg/cmd/formulas.go
+++ b/pkg/cmd/formulas.go
@@ -16,7 +16,7 @@ import (
 const (
 	subCommand  = " SUBCOMMAND"
 	Group       = "group"
-	localFlag   = "local"
+	dockerFlag  = "docker"
 	rootCmdName = "root"
 )
 
@@ -108,12 +108,12 @@ func (f FormulaCommand) execFormulaFunc(repo, path string) func(cmd *cobra.Comma
 			inputType = api.Stdin
 		}
 
-		local, err := cmd.Flags().GetBool(localFlag)
+		docker, err := cmd.Flags().GetBool(dockerFlag)
 		if err != nil {
 			return err
 		}
 
-		if err := f.formula.Run(d, inputType, local); err != nil {
+		if err := f.formula.Run(d, inputType, docker); err != nil {
 			return err
 		}
 
@@ -123,5 +123,5 @@ func (f FormulaCommand) execFormulaFunc(repo, path string) func(cmd *cobra.Comma
 
 func addFlags(cmd *cobra.Command) {
 	formulaFlags := cmd.Flags()
-	formulaFlags.BoolP(localFlag, "l", false, "Use to run formulas locally")
+	formulaFlags.BoolP(dockerFlag, "d", false, "Use to run formulas inside docker")
 }

--- a/pkg/credential/settings_test.go
+++ b/pkg/credential/settings_test.go
@@ -97,7 +97,7 @@ func TestNewDefaultCredentials(t *testing.T) {
 
 func TestProviderPath(t *testing.T) {
 	provider := credSettings.ProviderPath()
-	slicedPath := strings.Split(provider, "/")
+	slicedPath := strings.Split(provider, string(os.PathSeparator))
 	providersJson := slicedPath[len(slicedPath)-1]
 
 	if providersJson != "providers.json" {
@@ -107,7 +107,7 @@ func TestProviderPath(t *testing.T) {
 
 func TestCredentialsPath(t *testing.T){
 	credentials := credSettings.CredentialsPath()
-	slicedPath := strings.Split(credentials, "/")
+	slicedPath := strings.Split(credentials, string(os.PathSeparator))
 	fmt.Println(slicedPath)
 	providersDir := slicedPath[len(slicedPath)-1]
 

--- a/pkg/formula/builder/bat.go
+++ b/pkg/formula/builder/bat.go
@@ -1,21 +1,31 @@
 package builder
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
+	"github.com/ZupIT/ritchie-cli/pkg/stream"
 )
 
-const buildFile = "build.bat"
+const (
+	buildFile   = "build.bat"
+	msgBuildErr = "failed building formula with build.bat, verify your repository"
+	errMsgFmt   = `%s
+More about error: %s`
+)
 
-var ErrBuildFormulaBuildBat = errors.New("failed building formula with build.bat, verify your repository")
+var ErrBuildFormulaBuildBat = errors.New(msgBuildErr)
 
-type BatManager struct{}
+type BatManager struct {
+	file stream.FileExister
+}
 
-func NewBuildBat() formula.BatBuilder {
-	return BatManager{}
+func NewBuildBat(file stream.FileExister) formula.BatBuilder {
+	return BatManager{file: file}
 }
 
 func (ba BatManager) Build(formulaPath string) error {
@@ -23,10 +33,19 @@ func (ba BatManager) Build(formulaPath string) error {
 		return err
 	}
 
+	if !ba.file.Exists(buildFile) {
+		return ErrBuildOnWindows
+	}
+
+	var stderr bytes.Buffer
 	cmd := exec.Command(buildFile)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return ErrBuildFormulaBuildBat
+	}
+
+	if stderr.String() != "" {
+		return fmt.Errorf(errMsgFmt, msgBuildErr, stderr.String())
 	}
 
 	return nil

--- a/pkg/formula/builder/docker.go
+++ b/pkg/formula/builder/docker.go
@@ -33,7 +33,7 @@ func (do DockerManager) Build(formulaPath, dockerImg string) error {
 		return err
 	}
 
-	args := []string{"run", "-u", "0:0", "-v", volume, "--entrypoint", "/bin/sh", dockerImg, "-c", containerCmd}
+	args := []string{"run", "--rm", "-u", "0:0", "-v", volume, "--entrypoint", "/bin/sh", dockerImg, "-c", containerCmd}
 
 	var stderr bytes.Buffer
 	cmd := exec.Command("docker", args...)

--- a/pkg/formula/builder/local.go
+++ b/pkg/formula/builder/local.go
@@ -88,7 +88,6 @@ func (m LocalManager) buildFormulaBin(workspacePath, formulaPath, dest string) e
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-
 	if err := cmd.Run(); err != nil {
 		if stderr.Bytes() != nil {
 			errMsg := fmt.Sprintf("Build error: \n%s \n%s", stderr.String(), err)
@@ -96,6 +95,12 @@ func (m LocalManager) buildFormulaBin(workspacePath, formulaPath, dest string) e
 		}
 
 		return err
+	}
+
+	if so == osutil.Windows {
+		if stderr.String() != "" {
+			return fmt.Errorf("%s \nMore about error: %s", ErrBuildFormulaBuildBat, stderr.String())
+		}
 	}
 
 	return nil

--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -75,11 +75,11 @@ type (
 )
 
 type PreRunner interface {
-	PreRun(def Definition, local bool) (Setup, error)
+	PreRun(def Definition, docker bool) (Setup, error)
 }
 
 type Runner interface {
-	Run(def Definition, inputType api.TermInputType, local bool) error
+	Run(def Definition, inputType api.TermInputType, docker bool) error
 }
 
 type PostRunner interface {

--- a/pkg/formula/runner/post_run.go
+++ b/pkg/formula/runner/post_run.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/ZupIT/ritchie-cli/pkg/file/fileutil"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
@@ -21,10 +20,6 @@ func NewPostRunner(file stream.FileMoveRemover, dir stream.DirRemover) PostRunne
 func (po PostRunnerManager) PostRun(p formula.Setup, docker bool) error {
 	if docker {
 		if err := po.file.Remove(envFile); err != nil {
-			return err
-		}
-
-		if err := removeContainer(p.ContainerId); err != nil {
 			return err
 		}
 	}
@@ -47,15 +42,4 @@ func (po PostRunnerManager) removeWorkDir(tmpDir string) {
 	if err := po.dir.Remove(tmpDir); err != nil {
 		fmt.Sprintln("Error in remove dir")
 	}
-}
-
-func removeContainer(imgName string) error {
-	args := []string{"rm", imgName}
-	cmd := exec.Command(dockerCmd, args...)
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/formula/runner/pre_run.go
+++ b/pkg/formula/runner/pre_run.go
@@ -113,14 +113,14 @@ func (pr PreRunManager) buildFormula(formulaPath, dockerIB string, dockerFlag bo
 		}
 	}
 
-	if runtime.GOOS == osutil.Windows { // Build formula docker with build.bat
+	if runtime.GOOS == osutil.Windows { // Build formula local with build.bat
 		if err := pr.bat.Build(formulaPath); err != nil {
 			return err
 		}
 		return nil
 	}
 
-	if err := pr.make.Build(formulaPath); err != nil { // Build formula docker with Makefile
+	if err := pr.make.Build(formulaPath); err != nil { // Build formula local with Makefile
 		return err
 	}
 

--- a/pkg/formula/runner/pre_run.go
+++ b/pkg/formula/runner/pre_run.go
@@ -7,9 +7,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kaduartur/go-cli-spinner/pkg/spinner"
 
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
@@ -27,7 +27,7 @@ type PreRunManager struct {
 	make        formula.MakeBuilder
 	docker      formula.DockerBuilder
 	bat         formula.BatBuilder
-	dir         stream.DirCreateListCopier
+	dir         stream.DirCreateListCopyRemover
 	file        stream.FileReadExister
 }
 
@@ -36,7 +36,7 @@ func NewPreRun(
 	make formula.MakeBuilder,
 	docker formula.DockerBuilder,
 	bat formula.BatBuilder,
-	dir stream.DirCreateListCopier,
+	dir stream.DirCreateListCopyRemover,
 	file stream.FileReadExister,
 ) PreRunManager {
 	return PreRunManager{
@@ -49,7 +49,7 @@ func NewPreRun(
 	}
 }
 
-func (pr PreRunManager) PreRun(def formula.Definition, local bool) (formula.Setup, error) {
+func (pr PreRunManager) PreRun(def formula.Definition, docker bool) (formula.Setup, error) {
 	pwd, _ := os.Getwd()
 	formulaPath := def.FormulaPath(pr.ritchieHome)
 
@@ -62,8 +62,14 @@ func (pr PreRunManager) PreRun(def formula.Definition, local bool) (formula.Setu
 	if !pr.file.Exists(binFilePath) {
 		s := spinner.StartNew("Building formula...")
 		time.Sleep(2 * time.Second)
-		if err := pr.buildFormula(formulaPath, config.DockerIB, local); err != nil {
+		if err := pr.buildFormula(formulaPath, config.DockerIB, docker); err != nil {
 			s.Stop()
+
+			// Remove /bin dir to force formula rebuild in next execution
+			if err := pr.dir.Remove(def.BinPath(formulaPath)); err != nil {
+				return formula.Setup{}, err
+			}
+
 			return formula.Setup{}, err
 		}
 		s.Success(prompt.Green("Formula was successfully built!"))
@@ -88,8 +94,8 @@ func (pr PreRunManager) PreRun(def formula.Definition, local bool) (formula.Setu
 	}
 
 	dockerFile := filepath.Join(tmpDir, "Dockerfile")
-	if !local && validateDocker() && pr.file.Exists(dockerFile) {
-		s.ContainerId, err = buildRunImg()
+	if docker && validateDocker() && pr.file.Exists(dockerFile) {
+		s.ContainerId, err = buildRunImg(def)
 		if err != nil {
 			return formula.Setup{}, err
 		}
@@ -98,8 +104,8 @@ func (pr PreRunManager) PreRun(def formula.Definition, local bool) (formula.Setu
 	return s, nil
 }
 
-func (pr PreRunManager) buildFormula(formulaPath, dockerIB string, localFlag bool) error {
-	if !localFlag && dockerIB != "" && validateDocker() { // Build formula inside docker
+func (pr PreRunManager) buildFormula(formulaPath, dockerIB string, dockerFlag bool) error {
+	if dockerFlag && dockerIB != "" && validateDocker() { // Build formula inside docker
 		if err := pr.docker.Build(formulaPath, dockerIB); err != nil {
 			fmt.Println("\n" + err.Error())
 		} else {
@@ -107,14 +113,14 @@ func (pr PreRunManager) buildFormula(formulaPath, dockerIB string, localFlag boo
 		}
 	}
 
-	if runtime.GOOS == osutil.Windows { // Build formula local with build.bat
+	if runtime.GOOS == osutil.Windows { // Build formula docker with build.bat
 		if err := pr.bat.Build(formulaPath); err != nil {
 			return err
 		}
 		return nil
 	}
 
-	if err := pr.make.Build(formulaPath); err != nil { // Build formula local with Makefile
+	if err := pr.make.Build(formulaPath); err != nil { // Build formula docker with Makefile
 		return err
 	}
 
@@ -152,13 +158,15 @@ func (pr PreRunManager) createWorkDir(home, formulaPath string, def formula.Defi
 	return tDir, nil
 }
 
-func buildRunImg() (string, error) {
+func buildRunImg(def formula.Definition) (string, error) {
 	s := spinner.StartNew("Building docker image to run formula...")
-	containerId, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
+	formName := strings.ReplaceAll(def.Path, string(os.PathSeparator), "-")
+	containerId := fmt.Sprintf("rit-repo-%s-formula%s", def.RepoName, formName)
+	if len(containerId) > 200 {
+		containerId = containerId[:200]
 	}
-	args := []string{"build", "-t", containerId.String(), "."}
+
+	args := []string{"build", "-t", containerId, "."}
 	cmd := exec.Command(dockerCmd, args...) // Run command "docker build -t (randomId) ."
 	cmd.Stderr = os.Stderr
 
@@ -168,7 +176,7 @@ func buildRunImg() (string, error) {
 	}
 
 	s.Success(prompt.Green("Docker image successfully built!"))
-	return containerId.String(), err
+	return containerId, nil
 }
 
 // validate checks if able to run inside docker

--- a/pkg/formula/runner/runner.go
+++ b/pkg/formula/runner/runner.go
@@ -39,15 +39,14 @@ func NewFormulaRunner(
 	}
 }
 
-func (ru RunManager) Run(def formula.Definition, inputType api.TermInputType, local bool) error {
-	setup, err := ru.PreRun(def, local)
+func (ru RunManager) Run(def formula.Definition, inputType api.TermInputType, docker bool) error {
+	setup, err := ru.PreRun(def, docker)
 	if err != nil {
 		return err
 	}
 
-	var isDocker bool
 	var cmd *exec.Cmd
-	if local || setup.ContainerId == "" {
+	if !docker || setup.ContainerId == "" {
 		cmd, err = ru.runLocal(setup, inputType)
 		if err != nil {
 			return err
@@ -57,15 +56,13 @@ func (ru RunManager) Run(def formula.Definition, inputType api.TermInputType, lo
 		if err != nil {
 			return err
 		}
-
-		isDocker = true
 	}
 
 	if err := cmd.Run(); err != nil {
 		return err
 	}
 
-	if err := ru.PostRun(setup, isDocker); err != nil {
+	if err := ru.PostRun(setup, docker); err != nil {
 		return err
 	}
 
@@ -76,9 +73,9 @@ func (ru RunManager) runDocker(setup formula.Setup, inputType api.TermInputType)
 	volume := fmt.Sprintf("%s:/app", setup.Pwd)
 	var args []string
 	if isatty.IsTerminal(os.Stdout.Fd()) {
-		args = []string{"run", "-it", "--env-file", envFile, "-v", volume, "--name", setup.ContainerId, setup.ContainerId}
+		args = []string{"run", "--rm", "-it", "--env-file", envFile, "-v", volume, "--name", setup.ContainerId, setup.ContainerId}
 	} else {
-		args = []string{"run", "--env-file", envFile, "-v", volume, "--name", setup.ContainerId, setup.ContainerId}
+		args = []string{"run", "--rm", "--env-file", envFile, "-v", volume, "--name", setup.ContainerId, setup.ContainerId}
 	}
 
 	cmd := exec.Command(dockerCmd, args...) // Run command "docker run -env-file .env -v "$(pwd):/app" --name (randomId) (randomId)"

--- a/pkg/formula/runner/runner_test.go
+++ b/pkg/formula/runner/runner_test.go
@@ -23,7 +23,7 @@ func TestRun(t *testing.T) {
 	repoPath := filepath.Join(ritHome, "repos", "commons")
 
 	makeBuilder := builder.NewBuildMake()
-	batBuilder := builder.NewBuildBat()
+	batBuilder := builder.NewBuildBat(fileManager)
 
 	_ = dirManager.Remove(ritHome)
 	_ = dirManager.Remove(repoPath)
@@ -41,7 +41,7 @@ func TestRun(t *testing.T) {
 		postRun     formula.PostRunner
 		inputRun    formula.InputRunner
 		fileManager stream.FileWriteExistAppender
-		local       bool
+		docker      bool
 	}
 
 	type out struct {
@@ -61,7 +61,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunner,
 				fileManager: fileManager,
-				local:       true,
+				docker:      false,
 			},
 			out: out{
 				err: nil,
@@ -75,7 +75,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunnerMock{err: ErrInputNotRecognized},
 				fileManager: fileManager,
-				local:       true,
+				docker:      false,
 			},
 			out: out{
 				err: ErrInputNotRecognized,
@@ -89,7 +89,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunner,
 				fileManager: fileManager,
-				local:       true,
+				docker:      false,
 			},
 			out: out{
 				err: errors.New("pre runner error"),
@@ -103,7 +103,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunnerMock{err: errors.New("post runner error")},
 				inputRun:    inputRunner,
 				fileManager: fileManager,
-				local:       true,
+				docker:      false,
 			},
 			out: out{
 				err: errors.New("post runner error"),
@@ -117,7 +117,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunner,
 				fileManager: fileManager,
-				local:       false,
+				docker:      true,
 			},
 			out: out{
 				err: nil,
@@ -131,7 +131,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunnerMock{err: ErrInputNotRecognized},
 				fileManager: fileManager,
-				local:       false,
+				docker:      true,
 			},
 			out: out{
 				err: ErrInputNotRecognized,
@@ -145,7 +145,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunner,
 				fileManager: fileManagerMock{wErr: errors.New("error to write env file")},
-				local:       false,
+				docker:      true,
 			},
 			out: out{
 				err: errors.New("error to write env file"),
@@ -159,7 +159,7 @@ func TestRun(t *testing.T) {
 				postRun:     postRunner,
 				inputRun:    inputRunner,
 				fileManager: fileManagerMock{exist: true, aErr: errors.New("error to append env file")},
-				local:       false,
+				docker:      true,
 			},
 			out: out{
 				err: errors.New("error to append env file"),
@@ -171,7 +171,7 @@ func TestRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			in := tt.in
 			runner := NewFormulaRunner(in.postRun, in.inputRun, in.preRun, in.fileManager)
-			got := runner.Run(in.def, api.Prompt, in.local)
+			got := runner.Run(in.def, api.Prompt, in.docker)
 
 			if tt.out.err != nil && got != nil && tt.out.err.Error() != got.Error() {
 				t.Errorf("Run(%s) got %v, want %v", tt.name, got, tt.out.err)

--- a/pkg/formula/workspace.go
+++ b/pkg/formula/workspace.go
@@ -2,8 +2,8 @@ package formula
 
 const (
 	DefaultWorkspaceName = "Default"
-	DefaultWorkspaceDir  = "/ritchie-formulas-local"
-	WorkspacesFile       = "/formula_workspaces.json"
+	DefaultWorkspaceDir  = "ritchie-formulas-local"
+	WorkspacesFile       = "formula_workspaces.json"
 )
 
 type (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,4 +6,4 @@ for i in $(go list ./pkg/... | grep -v vendor/); do
   go tool cover -func=bin/cov.out
 done
 
-echo "\033[0;32m Unit tests run with success"
+echo "Unit tests performed successfully"


### PR DESCRIPTION
**- What I did**
- Removed docs dir from build formula list
- Removed `--local` and added `--docker` flag
- Check if build.bat file exist before to build a formula on Windows
- Add `--rm` in docker run command
- Check stderr when to build a formula locally on Windows
- Remove **/bin** when the formula building fail
- Now, formulas containers are built with the same formula name

**- How to verify it**
- Run unit tests
- Create and build a new formula on Windows

**- Description for the changelog**