### PR TITLE
Remove image docker post run

### DIFF
--- a/pkg/formula/runner/post_run.go
+++ b/pkg/formula/runner/post_run.go
@@ -43,6 +43,10 @@ func (po PostRunnerManager) PostRun(p formula.Setup, docker bool) error {
 		if err := removeContainer(p.ContainerId); err != nil {
 			return err
 		}
+
+		if err := removeImage(p.ContainerId); err != nil {
+			return err
+		}
 	}
 
 	defer po.removeWorkDir(p.TmpDir)
@@ -67,6 +71,17 @@ func (po PostRunnerManager) removeWorkDir(tmpDir string) {
 
 func removeContainer(imgName string) error {
 	args := []string{"rm", imgName}
+	cmd := exec.Command(dockerCmd, args...)
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeImage(imgName string) error {
+	args := []string{"rmi", imgName}
 	cmd := exec.Command(dockerCmd, args...)
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
**- What I did**
Added a command to completely remove the image from the embedded Docker after execution. It will never be reused and takes up a lot of space on the user's computer. Some with almost 2GB.
The current implementation removed only the container.

**- How to verify it**
Run any formula more than once and you will see that several builds with random ids are generated.
With this implementation, after the execution the image is removed as well as the container.

**- Description for the changelog**
Added a complete removal of the docker image after execution, to save disk space.

Examples of garbage images before implementation:

![images-docker](https://user-images.githubusercontent.com/58859234/88995603-7adc4b00-d2c1-11ea-8a3f-1d00a49b0241.png)

