### PR TITLE
change errKeyNotFoundTemplate

### DIFF
--- a/pkg/env/envcredential/env_credential.go
+++ b/pkg/env/envcredential/env_credential.go
@@ -29,7 +29,8 @@ type CredentialResolver struct {
 	credential.Finder
 }
 
-const errKeyNotFoundTemplate = `Provider %s has not credential:%s to fix this, verify config.json of formula`
+const errKeyNotFoundTemplate = `Provider %s has not the credential type %s.
+Please verify formula's config.json`
 
 // NewResolver creates a credential resolver instance of Resolver interface
 func NewResolver(cf credential.Finder) CredentialResolver {


### PR DESCRIPTION
**- What I did**
Change error message:
Error: Provider aws has not credential:CREDENTIAL_AWS_ACCESSKEY to fix this, verify config.json of formula

Suggest
Error: Provider aws has not the credential type CREDENTIAL_AWS_ACCESSKEY. Please verify formula's config.json

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
