### PR TITLE
[FIX] Java formula uberjar packaging

### DIFF
--- a/testdata/repos/commons/templates/create_formula/languages/java/Makefile
+++ b/testdata/repos/commons/templates/create_formula/languages/java/Makefile
@@ -4,7 +4,7 @@ SH=$(BIN_FOLDER)/run.sh
 BAT=$(BIN_FOLDER)/run.bat
 BUILD=mvn clean install
 CLEAN=mvn clean
-JAR_FILE=Main.jar
+JAR_FILE=Main-jar-with-dependencies.jar
 TARGET=target
 
 build: java-build sh-unix bat-windows

--- a/testdata/repos/commons/templates/create_formula/languages/java/pom.xml
+++ b/testdata/repos/commons/templates/create_formula/languages/java/pom.xml
@@ -31,6 +31,29 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- Build an executable (uber)JAR with all dependencies inside-->
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<!-- <addClasspath>true</addClasspath> -->
+							<mainClass>com.ritchie.Main</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Fixed java JAR packages generation for Java formulas.

JAR files contain, by default, only source code packages, and not its dependencies. Java formula template covers only simple execution of JARs, leaving external libraries out of scope. For a simple Java application that only uses JDK classes, that's OK but, in most scenarios, external libraries are required. For that to work properly, those libraries classes must be in the classpath. The easiest/quickest way to achieve that is to embed all classes in a single JAR.

**NOTE:** `Makefile` now uses the Uber JAR `Main-jar-with-dependencies.jar` instead of `Main.jar` to execute the formula. The `Main-jar-with-dependencies.jar`, depending on how many external dependencies were added, is going to be much larger than the regular `Main.jar` file. And `pom.xml` now declares a `maven-assembly-plugin` that embeds all dependencies packages inside the JAR file.

**NOTE 2:** I'm not sure if that's the right place to edit templates for creating formulas, because I noticed this issue while using Ritche. All I know is those 2 changes are paramount to avoid classpath errors when someone edits the Java code. 9 out of 10 times, Java developers that use external dependencies will run into classpath issues using Ritchie if this isn't addressed, assuming that Maven execution will have proper classpath handling, when it really doesn't. That is why Maven Assembly Plugin can cover most bases now but needs tuning for more complex scenarios.

**- How to verify it**
Before:
- Create any java-based formula.
- Edit the java code to perform a task that requires external dependencies (example: reading files using [commons-io](https://mvnrepository.com/artifact/commons-io/commons-io/2.7)).
- Add `commons-io` dependencies to the `pom.xml`
- Build the formula
- Execute the formula
- **Result:** Java ClassPath error. Probably a `NoClassDefFoundError` because `commons-io` classes aren't inside the `Main.jar`

Now:
- Create any java-based formula.
- Edit the java code to perform a task that requires external dependencies (example: reading files using [commons-io](https://mvnrepository.com/artifact/commons-io/commons-io/2.7)).
- Add `commons-io` dependencies to the `pom.xml`
- Build the formula
- Execute the formula
- **Result:** no Java ClassPath errors.

**- Description for the changelog**

Fixed ClassPath errors in Java-based formulas due to bad JAR files generation by adding Maven Assembly Plugin execution to the template.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
