### PR TITLE
[FIX] Add repo with the commons name

### DIFF
--- a/pkg/cmd/add_repo.go
+++ b/pkg/cmd/add_repo.go
@@ -29,9 +29,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 )
 
-const (
-	defaultRepoUrl = "https://github.com/ZupIT/ritchie-formulas"
-)
+const defaultRepoUrl = "https://github.com/ZupIT/ritchie-formulas"
 
 var ErrRepoNameNotEmpty = errors.New("the field repository name must not be empty")
 
@@ -99,13 +97,14 @@ func (ad addRepoCmd) runPrompt() CommandRunnerFunc {
 
 		for i := range repos {
 			repo := repos[i]
-			if repo.Name == "commons" {
-				prompt.Warning("You are trying to replace the \"common\" repository!")
+			if repo.Name == formula.RepoCommonsName && formula.RepoName(name) == formula.RepoCommonsName {
+				prompt.Warning("You are trying to replace the \"commons\" repository!")
 				choice, _ := ad.Bool("Do you want to proceed?", []string{"yes", "no"})
 				if !choice {
 					prompt.Info("Operation cancelled")
 					return nil
 				}
+				break
 			}
 
 			if repo.Name == formula.RepoName(name) {

--- a/pkg/formula/repo.go
+++ b/pkg/formula/repo.go
@@ -18,6 +18,8 @@ package formula
 
 import "github.com/ZupIT/ritchie-cli/pkg/git"
 
+const RepoCommonsName = RepoName("commons")
+
 type Repo struct {
 	Provider RepoProvider `json:"provider"`
 	Name     RepoName     `json:"name"`


### PR DESCRIPTION
**- What I did**
- I added a check if the repo name is equal the "commons" name

**- How to verify it**
Run `rit add repo` after running` rit init`, in the repository name type "commons", the following message should appear "You are trying to replace the" commons "repository!", But if the name of the repository is different, this message should not be displayed.

**- Description for the changelog**
Fix add repo with the commons name
