### PR TITLE
Adds question about metrics in init

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,7 +147,7 @@ func buildCommands() *cobra.Command {
 	addCmd := cmd.NewAddCmd()
 	createCmd := cmd.NewCreateCmd()
 	deleteCmd := cmd.NewDeleteCmd()
-	initCmd := cmd.NewInitCmd(repoAdder, githubRepo, tutorialFinder, inputBool)
+	initCmd := cmd.NewInitCmd(repoAdder, githubRepo, tutorialFinder, inputList, fileManager)
 	listCmd := cmd.NewListCmd()
 	setCmd := cmd.NewSetCmd()
 	showCmd := cmd.NewShowCmd()

--- a/functional/init/init_feature.json
+++ b/functional/init/init_feature.json
@@ -89,6 +89,11 @@
                 "key":"Would you like to add the community repository? [https://github.com/ZupIT/ritchie-formulas]",
                 "value":"yes",
                 "action":"select"
+            },
+            {
+                "key":"To help us improve and deliver more value to the community, do you agree to let us collect anonymous data about product and feature use statistics and crash reports?",
+                "value":"Yes, I agree to contribute with data anonymously",
+                "action":"select"
             }
         ],
         "result":""

--- a/functional/runner_unix.go
+++ b/functional/runner_unix.go
@@ -78,9 +78,16 @@ func setUpRitSingleUnix() {
 
 	fmt.Println("Running INIT")
 	initStepRit := Step{Key: "", Value: "init", Action: "rit"}
-	initAddRepo := Step{Key: "Would you like to add the community repository? [https://github.com/ZupIT/ritchie-formulas]", Value: "yes", Action: "select"}
+	initAddRepo := Step{
+		Key:    "Would you like to add the community repository? [https://github.com/ZupIT/ritchie-formulas]",
+		Value:  "yes",
+		Action: "select"}
+	initAcceptsMetrics := Step{
+		Key:    "To help us improve and deliver more value to the community, do you agree to let us collect anonymous data about product and feature use statistics and crash reports?",
+		Value:  "Yes, I agree to contribute with data anonymously",
+		Action: "select"}
 
-	init := Scenario{Entry: "Running Init", Result: "", Steps: []Step{initStepRit, initAddRepo}}
+	init := Scenario{Entry: "Running Init", Result: "", Steps: []Step{initStepRit, initAddRepo, initAcceptsMetrics}}
 
 	err, _ := init.runStepsForUnix()
 	if err != nil {

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/git/github"
+	"github.com/ZupIT/ritchie-cli/pkg/metric"
+	"github.com/ZupIT/ritchie-cli/pkg/stream"
 
 	"github.com/kaduartur/go-cli-spinner/pkg/spinner"
 
@@ -34,15 +36,19 @@ import (
 )
 
 const (
-	addRepoMsg = "Run \"rit add repo\" to add a new repository manually."
+	addRepoMsg         = "Run \"rit add repo\" to add a new repository manually."
+	AddCommonsQuestion = "Would you like to add the community repository? [https://github.com/ZupIT/ritchie-formulas]"
+	AddMetricsQuestion = "To help us improve and deliver more value to the community, do you agree to let us collect anonymous data about product and feature use statistics and crash reports?"
+	AcceptMetrics      = "Yes, I agree to contribute with data anonymously"
+	DoNotAcceptMetrics = "No, not for now."
 )
 
 var (
 	addRepoInfo = `You can keep the configuration without adding the community repository,
-but you will need to provide a git repo with the formulas templates and add them with 
-rit add repo command, naming this repository obligatorily as "commons".
-
-See how to do this on the example: [https://github.com/ZupIT/ritchie-formulas/blob/master/templates/create_formula/README.md]`
+ but you will need to provide a git repo with the formulas templates and add them with 
+ rit add repo command, naming this repository obligatorily as "commons".
+ 
+ See how to do this on the example: [https://github.com/ZupIT/ritchie-formulas/blob/master/templates/create_formula/README.md]`
 	errMsg             = prompt.Yellow("It was not possible to add the commons repository at this time, please try again later.")
 	ErrInitCommonsRepo = errors.New(errMsg)
 	CommonsRepoURL     = "https://github.com/ZupIT/ritchie-formulas"
@@ -52,11 +58,12 @@ type initCmd struct {
 	repo formula.RepositoryAdder
 	git  git.Repositories
 	rt   rtutorial.Finder
-	prompt.InputBool
+	prompt.InputList
+	stream.FileWriteReadExister
 }
 
-func NewInitCmd(repo formula.RepositoryAdder, git git.Repositories, rtf rtutorial.Finder, inBool prompt.InputBool) *cobra.Command {
-	o := initCmd{repo: repo, git: git, rt: rtf, InputBool: inBool}
+func NewInitCmd(repo formula.RepositoryAdder, git git.Repositories, rtf rtutorial.Finder, inList prompt.InputList, file stream.FileWriteReadExister) *cobra.Command {
+	o := initCmd{repo: repo, git: git, rt: rtf, InputList: inList, FileWriteReadExister: file}
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -70,48 +77,49 @@ func NewInitCmd(repo formula.RepositoryAdder, git git.Repositories, rtf rtutoria
 
 func (in initCmd) runPrompt() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		label := "Would you like to add the community repository? [https://github.com/ZupIT/ritchie-formulas]"
-		choose, err := in.Bool(label, []string{"yes", "no"})
+		choose, err := in.List(AddCommonsQuestion, []string{"yes", "no"})
 		if err != nil {
 			return err
 		}
 
-		if !choose {
+		if choose != "yes" {
 			fmt.Println()
 			prompt.Warning(addRepoInfo)
 			fmt.Println()
 			fmt.Println(addRepoMsg)
-			return nil
+		} else {
+			repo := formula.Repo{
+				Provider: "Github",
+				Name:     "commons",
+				Url:      CommonsRepoURL,
+				Priority: 0,
+			}
+
+			s := spinner.StartNew("Adding the commons repository...")
+			time.Sleep(time.Second * 2)
+
+			repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
+
+			tag, err := in.git.LatestTag(repoInfo)
+			if err != nil {
+				s.Error(ErrInitCommonsRepo)
+				fmt.Println(addRepoMsg)
+			}
+
+			repo.Version = formula.RepoVersion(tag.Name)
+
+			if err := in.repo.Add(repo); err != nil {
+				s.Error(ErrInitCommonsRepo)
+				fmt.Println(addRepoMsg)
+			}
+
+			s.Success(prompt.Green("Commons repository added successfully!"))
 		}
 
-		repo := formula.Repo{
-			Provider: "Github",
-			Name:     "commons",
-			Url:      CommonsRepoURL,
-			Priority: 0,
-		}
-
-		s := spinner.StartNew("Adding the commons repository...")
-		time.Sleep(time.Second * 2)
-
-		repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
-
-		tag, err := in.git.LatestTag(repoInfo)
+		err = metricsAuthorization(in.InputList, in.FileWriteReadExister)
 		if err != nil {
-			s.Error(ErrInitCommonsRepo)
-			fmt.Println(addRepoMsg)
-			return nil
+			return err
 		}
-
-		repo.Version = formula.RepoVersion(tag.Name)
-
-		if err := in.repo.Add(repo); err != nil {
-			s.Error(ErrInitCommonsRepo)
-			fmt.Println(addRepoMsg)
-			return nil
-		}
-
-		s.Success(prompt.Green("Initialization successful!"))
 
 		tutorialHolder, err := in.rt.Find()
 		if err != nil {
@@ -126,11 +134,38 @@ func tutorialInit(tutorialStatus string) {
 	const tagTutorial = "\n[TUTORIAL]"
 	const MessageTitle = "How to create new formulas:"
 	const MessageBody = ` ∙ Run "rit create formula"
- ∙ Open the project with your favorite text editor.` + "\n"
+  ∙ Open the project with your favorite text editor.` + "\n"
 
 	if tutorialStatus == tutorialStatusEnabled {
 		prompt.Info(tagTutorial)
 		prompt.Info(MessageTitle)
 		fmt.Println(MessageBody)
 	}
+}
+
+func metricsAuthorization(inList prompt.InputList, file stream.FileWriteReadExister) error {
+	const welcome = "\n\nWelcome to Ritchie!"
+	const header = "Ritchie is a platform that helps you and your team to save time by giving you the power to create powerful templates to execute important tasks across your team and organization with minimum time and with standards, delivering autonomy to developers with security.\nYou can view our Privacy Policy (http://insights.zup.com.br/politica-privacidade) to better understand our commitment."
+	const footer = "You can always modify your choice using the \"rit metrics\" command."
+	options := []string{AcceptMetrics, DoNotAcceptMetrics}
+
+	prompt.Info(welcome)
+	fmt.Println(header)
+
+	choose, err := inList.List(AddMetricsQuestion, options)
+	if err != nil {
+		return err
+	}
+	fmt.Println(footer)
+
+	responseToWrite := "yes"
+	if choose == DoNotAcceptMetrics {
+		responseToWrite = "no"
+	}
+
+	err = file.Write(metric.MetricsPath(), []byte(responseToWrite))
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/git/github"
-	"github.com/ZupIT/ritchie-cli/pkg/metric"
+	"github.com/ZupIT/ritchie-cli/pkg/metrics"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
 
 	"github.com/kaduartur/go-cli-spinner/pkg/spinner"
@@ -163,7 +163,7 @@ func metricsAuthorization(inList prompt.InputList, file stream.FileWriteReadExis
 		responseToWrite = "no"
 	}
 
-	err = file.Write(metric.MetricsPath(), []byte(responseToWrite))
+	err = file.Write(metrics.FilePath, []byte(responseToWrite))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Created the metrics contract in the init command flow.

> ![metrics](https://user-images.githubusercontent.com/14079465/89951540-00d18d80-dc02-11ea-9b0b-33cae288d46e.gif)


**- How to verify it**
To check the functionality it is indicated:
1. Clone the ritchie-cli repository:
 `git clone https://github.com/ZupIT/ritchie-cli`
2. Clone this PR with the command:
 `git fetch origin pull/399/head:feature/add-question-about-sending-metrics-in-init
3. Execute `rit init`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Created the metrics contract in the init command flow.
