### PR TITLE
Add entry via stdin to the init command

### DIFF
--- a/functional/stdin/stdin_feature.json
+++ b/functional/stdin/stdin_feature.json
@@ -1,5 +1,22 @@
 [
     {
+        "entry":"Init STDIN",
+        "steps":[
+            {
+                "key":"",
+                "value":"{\"addRepo\":\"yes\"}",
+                "action":"echo"
+            },
+            {
+                "key":"",
+                "value":"init --stdin",
+                "action":"main"
+            }
+
+        ],
+        "result":"Initialization successful!"
+    },
+    {
         "entry":"Set context STDIN",
         "steps":[
             {

--- a/functional/stdin/stdin_integration_test.go
+++ b/functional/stdin/stdin_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/functional"
 )
 
-func TestRitSingleStdin(t *testing.T) {
+func TestRitStdin(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Rit Suite Stdin")
 }
@@ -45,12 +45,11 @@ var _ = Describe("RitStdin", func() {
 			Expect(out).To(ContainSubstring(scenario.Result))
 		},
 
-		Entry("Set context STDIN", scenariosStdin[0]),
-		Entry("Delete context STDIN", scenariosStdin[1]),
-		Entry("Add new repo STDIN", scenariosStdin[2]),
-		Entry("Delete repo STDIN", scenariosStdin[3]),
-		Entry("Set credentials STDIN", scenariosStdin[4]),
-
+		Entry(scenariosStdin[0].Entry, scenariosStdin[0]),
+		Entry(scenariosStdin[1].Entry, scenariosStdin[1]),
+		Entry(scenariosStdin[2].Entry, scenariosStdin[2]),
+		Entry(scenariosStdin[3].Entry, scenariosStdin[3]),
+		Entry(scenariosStdin[4].Entry, scenariosStdin[4]),
+		Entry(scenariosStdin[5].Entry, scenariosStdin[5]),
 	)
-
 })

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -49,7 +49,6 @@ See how to do this on the example: [https://github.com/ZupIT/ritchie-formulas/bl
 	CommonsRepoURL     = "https://github.com/ZupIT/ritchie-formulas"
 )
 
-// setContext type for stdin json decoder
 type initStdin struct {
 	AddRepo string `json:"addRepo"`
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/ZupIT/ritchie-cli/pkg/git"
@@ -133,7 +132,7 @@ func (in initCmd) runStdin() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		init := initStdin{}
 
-		err := stdin.ReadJson(os.Stdin, &init)
+		err := stdin.ReadJson(cmd.InOrStdin(), &init)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -137,9 +137,8 @@ func (in initCmd) runStdin() CommandRunnerFunc {
 		}
 
 		if init.AddRepo == "no" {
-			fmt.Println()
-			prompt.Warning(addRepoInfo)
-			fmt.Println()
+			fmt.Printf("\n%s\n", prompt.Yellow(addRepoInfo))
+
 			fmt.Println(addRepoMsg)
 		} else {
 			s := spinner.StartNew("Adding the commons repository...")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -19,10 +19,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/git/github"
+	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 
 	"github.com/kaduartur/go-cli-spinner/pkg/spinner"
 
@@ -48,6 +50,11 @@ See how to do this on the example: [https://github.com/ZupIT/ritchie-formulas/bl
 	CommonsRepoURL     = "https://github.com/ZupIT/ritchie-formulas"
 )
 
+// setContext type for stdin json decoder
+type initStdin struct {
+	AddRepo string `json:"addRepo"`
+}
+
 type initCmd struct {
 	repo formula.RepositoryAdder
 	git  git.Repositories
@@ -62,7 +69,7 @@ func NewInitCmd(repo formula.RepositoryAdder, git git.Repositories, rtf rtutoria
 		Use:   "init",
 		Short: "Initialize rit configuration",
 		Long:  "Initialize rit configuration",
-		RunE:  o.runPrompt(),
+		RunE:  RunFuncE(o.runStdin(), o.runPrompt()),
 	}
 
 	return cmd
@@ -112,6 +119,60 @@ func (in initCmd) runPrompt() CommandRunnerFunc {
 		}
 
 		s.Success(prompt.Green("Initialization successful!"))
+
+		tutorialHolder, err := in.rt.Find()
+		if err != nil {
+			return err
+		}
+		tutorialInit(tutorialHolder.Current)
+		return nil
+	}
+}
+
+func (in initCmd) runStdin() CommandRunnerFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		init := initStdin{}
+
+		err := stdin.ReadJson(os.Stdin, &init)
+		if err != nil {
+			return err
+		}
+
+		if init.AddRepo == "no" {
+			fmt.Println()
+			prompt.Warning(addRepoInfo)
+			fmt.Println()
+			fmt.Println(addRepoMsg)
+		} else {
+			s := spinner.StartNew("Adding the commons repository...")
+			time.Sleep(time.Second * 2)
+
+			repo := formula.Repo{
+				Provider: "Github",
+				Name:     "commons",
+				Url:      CommonsRepoURL,
+				Priority: 0,
+			}
+
+			repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
+
+			tag, err := in.git.LatestTag(repoInfo)
+			if err != nil {
+				s.Error(ErrInitCommonsRepo)
+				fmt.Println(addRepoMsg)
+				return nil
+			}
+
+			repo.Version = formula.RepoVersion(tag.Name)
+
+			if err := in.repo.Add(repo); err != nil {
+				s.Error(ErrInitCommonsRepo)
+				fmt.Println(addRepoMsg)
+				return nil
+			}
+
+			s.Success(prompt.Green("Initialization successful!"))
+		}
 
 		tutorialHolder, err := in.rt.Find()
 		if err != nil {

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -101,9 +101,9 @@ func (inputPasswordMock) Password(label string) (string, error) {
 	return "s3cr3t", nil
 }
 
-type inputPasswordErrorMock struct {}
+type inputPasswordErrorMock struct{}
 
-func (inputPasswordErrorMock) Password(label string) (string, error){
+func (inputPasswordErrorMock) Password(label string) (string, error) {
 	return "", errors.New("password error")
 }
 
@@ -123,6 +123,12 @@ type inputFalseMock struct{}
 
 func (inputFalseMock) Bool(name string, items []string) (bool, error) {
 	return false, nil
+}
+
+type inputBoolErrorMock struct{}
+
+func (inputBoolErrorMock) Bool(name string, items []string) (bool, error) {
+	return true, errors.New("some error")
 }
 
 type inputListMock struct{}
@@ -289,19 +295,19 @@ func (s credSettingsMock) CredentialsPath() string {
 }
 
 type credSettingsCustomMock struct {
-	ReadCredentialsValueMock func(path string)([]credential.ListCredData, error)
-	ReadCredentialsFieldsMock func(path string) (credential.Fields, error)
+	ReadCredentialsValueMock          func(path string) ([]credential.ListCredData, error)
+	ReadCredentialsFieldsMock         func(path string) (credential.Fields, error)
 	WriteDefaultCredentialsFieldsMock func(path string) error
-	WriteCredentialsFieldsMock func (fields credential.Fields, path string) error
-	ProviderPathMock func () string
-	CredentialsPathMock func () string
+	WriteCredentialsFieldsMock        func(fields credential.Fields, path string) error
+	ProviderPathMock                  func() string
+	CredentialsPathMock               func() string
 }
 
 func (cscm credSettingsCustomMock) ReadCredentialsFields(path string) (credential.Fields, error) {
 	return cscm.ReadCredentialsFieldsMock(path)
 }
 
-func (cscm credSettingsCustomMock) ReadCredentialsValue (path string)([]credential.ListCredData, error) {
+func (cscm credSettingsCustomMock) ReadCredentialsValue(path string) ([]credential.ListCredData, error) {
 	return cscm.ReadCredentialsValueMock(path)
 }
 
@@ -320,8 +326,6 @@ func (cscm credSettingsCustomMock) ProviderPath() string {
 func (cscm credSettingsCustomMock) CredentialsPath() string {
 	return ""
 }
-
-
 
 type runnerMock struct {
 	error error


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Add entry via stdin to the init command. - Also includes stdin tests for init - Updates tests from the init_test.go file to include stdin tests.

**- How to verify it**

Clone this pr with the command and build Ritchie
```bash
git fetch upstream pull/426/head:feature/add-entry-via-stdin-to-the-init-command
git checkout feature/add-entry-via-stdin-to-the-init-command
make build && sudo cp dist/linux/rit /usr/local/bin/
```

Run tests
 ```bash
make functional-test # Search for "Running STDIN: Init STDIN"
make unit-test # Search for "=== RUN   TestNewInitStdin"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add entry via stdin to the init command.