### PR TITLE
Adding conditional steps to config prompt

### DIFF
--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -43,18 +43,24 @@ const (
 
 type (
 	Input struct {
-		Name    string   `json:"name"`
-		Type    string   `json:"type"`
-		Default string   `json:"default"`
-		Label   string   `json:"label"`
-		Items   []string `json:"items"`
-		Cache   Cache    `json:"cache"`
+		Name    	string   	`json:"name"`
+		Type    	string   	`json:"type"`
+		Default 	string   	`json:"default"`
+		Label   	string   	`json:"label"`
+		Items   	[]string 	`json:"items"`
+		Cache   	Cache    	`json:"cache"`
+		Condition	Condition	`json:"condition"`
 	}
 
 	Cache struct {
 		Active   bool   `json:"active"`
 		Qty      int    `json:"qty"`
 		NewLabel string `json:"newLabel"`
+	}
+	Condition struct {
+		Variable	string `json:"variable"`
+		Operator	string `json:"operator"`
+		Value		string `json:"value"`
 	}
 	Create struct {
 		FormulaCmd    string `json:"formulaCmd"`

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -18,7 +18,6 @@ package runner
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -271,7 +270,7 @@ func (in InputManager) verifyConditional(cmd *exec.Cmd, input formula.Input) (bo
 		}
 	}
 	if value == "" {
-		return false, errors.New(fmt.Sprintf("config.json: conditional variable %s not found", variable))
+		return false, fmt.Errorf("config.json: conditional variable %s not found", variable)
 	}
 
 	// Currently using case implementation to avoid adding a dependency module or exposing
@@ -285,9 +284,9 @@ func (in InputManager) verifyConditional(cmd *exec.Cmd, input formula.Input) (bo
 	case "<":  return value < input.Condition.Value, nil
 	case "<=": return value <= input.Condition.Value, nil
 	default:
-		return false, errors.New(fmt.Sprintf(
+		return false, fmt.Errorf(
 			"config.json: conditional operator %s not valid. Use any of (==, !=, >, >=, <, <=)",
 			input.Condition.Operator,
-		))
+		)
 	}
 }

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -330,6 +330,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 	tests := []struct {
 		name string
 		in   in
+		want error
 	}{
 		{
 			name: "equal conditional",
@@ -337,6 +338,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    "==",
 			},
+			want: nil,
 		},
 		{
 			name: "not equal conditional",
@@ -344,6 +346,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    "!=",
 			},
+			want: nil,
 		},
 		{
 			name: "greater than conditional",
@@ -351,6 +354,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    ">",
 			},
+			want: nil,
 		},
 		{
 			name: "greater than or equal to conditional",
@@ -358,6 +362,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    ">=",
 			},
+			want: nil,
 		},
 		{
 			name: "less than conditional",
@@ -365,6 +370,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    "<",
 			},
+			want: nil,
 		},
 		{
 			name: "less than or equal to conditional",
@@ -372,6 +378,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    "<=",
 			},
+			want: nil,
 		},
 		{
 			name: "wrong operator conditional",
@@ -379,6 +386,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "sample_list",
 				operator:    "eq",
 			},
+			want: errors.New("config.json: conditional operator eq not valid. Use any of (==, !=, >, >=, <, <=)"),
 		},
 		{
 			name: "non-existing variable conditional",
@@ -386,6 +394,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				variable:    "non_existing",
 				operator:    "==",
 			},
+			want: errors.New("config.json: conditional variable non_existing not found"),
 		},
 	}
 
@@ -412,8 +421,8 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 
 			got := inputManager.Inputs(cmd, setup, api.Prompt)
 
-			if got != nil {
-				t.Errorf("Error on conditional Inputs(%s): %v", tt.name, got)
+			if got != tt.want {
+				t.Errorf("Error on conditional Inputs(%s): got %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -421,7 +421,7 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 
 			got := inputManager.Inputs(cmd, setup, api.Prompt)
 
-			if got != tt.want {
+			if (tt.want != nil && got == nil) || got != nil && got.Error() != tt.want.Error() {
 				t.Errorf("Error on conditional Inputs(%s): got %v, want %v", tt.name, got, tt.want)
 			}
 		})

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -75,6 +75,11 @@ func TestInputManager_Inputs(t *testing.T) {
             "false",
             "true"
         ],
+		"condition": {
+			"variable": "sample_list",
+			"operator": "==",
+			"value": "in_list1"
+		},
         "label": "Pick: "
     },
     {
@@ -148,6 +153,19 @@ func TestInputManager_Inputs(t *testing.T) {
 			in: in{
 				iText:       inputMock{text: ""},
 				iList:       inputMock{text: "Type new value?"},
+				iBool:       inputMock{boolean: false},
+				iPass:       inputMock{text: "******"},
+				inType:      api.Prompt,
+				creResolver: env.Resolvers{"CREDENTIAL": envResolverMock{in: "test"}},
+				file:        fileManager,
+			},
+			want: nil,
+		},
+		{
+			name: "success conditional prompt",
+			in: in{
+				iText:       inputMock{text: ""},
+				iList:       inputMock{text: "in_list1"},
 				iBool:       inputMock{boolean: false},
 				iPass:       inputMock{text: "******"},
 				inType:      api.Prompt,


### PR DESCRIPTION
## Description
As requested on issue #390, this PR allows the developer to specify optional inputs according to previous user inputs. The user needs to create a key called `condition` on an optional step and provide a variable reference from any previous variable defined, an operator for comparison (==, !=, >, >=, <, <=), and a value to compare. If the condition exists and fails, the current step is not shown.

This is a simple implementation some of the points taken in account are explained below:

* The comparison operators are implemented in a `case` like manner. It is not very elegant. The better approach would be to evaluate the expression, but it was not chosen because:
    1. Go does not come with a native `eval` function and it would require to add a dependency to the project for a simple task
    2. Since many times the user input is free we could risk him adding harmful code as a value and executing it on an `eval` command or letting the author add malicious code on the `operator` variable
* This approach only attends simple expressions between a single variable and a value. Complex multi-variable expressions are not supported for the sake of avoiding overengineering. This should cover most of the cases, I think it is better to wait for the community to demand more complex interactions before we actually implement them.
* There are discussions to create tree-like decisions to prompt the user. This implementation does not rule that out, we can still implement a decision tree with conditional nodes, so forward-compatibility is accounted for.
* In case the user uses a wrong operator. An error is thrown
* In case the user defines a non existing variable name. An error is thrown

Suggestions are welcome!

## How to verify it
Create a condition key on `config.json` of a formula like on this example
```
{
      "cache": {
        "active": true,
        "newLabel": "Type new value. ",
        "qty": 6
      },
      "label": "Type : ",
      "name": "sample_text",
      "condition": {
          "variable": "sample_list",
          "operator": "==",
          "value": "in_list1"
      },
      "type": "text"
    },
```
Run the formula and **fail the condition** to have this prompt not shown

## Description for the changelog
Adding conditional steps to config prompt

![Aug-20-2020 21-27-16](https://user-images.githubusercontent.com/68074718/90841197-76d8a180-e332-11ea-820a-165ee1636853.gif)
