### PR TITLE
Adding EMAIL to GITLAB credential

### DIFF
--- a/pkg/credential/settings.go
+++ b/pkg/credential/settings.go
@@ -199,7 +199,7 @@ func NewDefaultCredentials() Fields {
 	dc := Fields{
 		AddNew:       []Field{},
 		"github":     []Field{username, email, token},
-		"gitlab":     []Field{username, token},
+		"gitlab":     []Field{username, email, token},
 		"aws":        []Field{accessKey, secretAccessKey},
 		"jenkins":    []Field{username, token},
 		"kubeconfig": []Field{base64config},


### PR DESCRIPTION
**- What I did**

- Adding email variable to gitlab credential for **rit gitlab publish repo** formula (https://github.com/ZupIT/ritchie-formulas/pull/153).

**- How to verify it**

- Use the **rit set credential** command and set Gitlab credential to see the email appearing.

**- Description for the changelog**

-  Adding EMAIL to GITLAB credential

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
