### PR TITLE
Add the 'password' input type to stdin

### DIFF
--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -96,7 +96,7 @@ func (in InputManager) fromStdin(cmd *exec.Cmd, setup formula.Setup) error {
 		var inputVal string
 		var err error
 		switch iType := input.Type; iType {
-		case "text", "bool":
+		case "text", "bool", "password":
 			inputVal = fmt.Sprintf("%v", data[input.Name])
 		default:
 			inputVal, err = in.resolveIfReserved(input)


### PR DESCRIPTION
**- What I did**

- Added the 'password' input type to stdin when running formulas

**- How to verify it**

- Build this branch and run this command to test:
```sh
echo '{"input_text":"Dennis", "input_bool":"false", "input_list":"everything", "input_password":"Ritchie"}' | rit demo hello-world --stdin
```

**- Description for the changelog**
Add the 'password' input type to stdin
