### PR TITLE
 Duplication of letters in the command list credentials

### DIFF
--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -57,7 +57,6 @@ func (u UpgradeCmd) runFunc() CommandRunnerFunc {
 		if err != nil {
 			return prompt.NewError(err.Error()+"\n")
 		}
-
 		prompt.Success("Rit upgraded with success")
 		return nil
 	}

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -57,6 +57,7 @@ func (u UpgradeCmd) runFunc() CommandRunnerFunc {
 		if err != nil {
 			return prompt.NewError(err.Error()+"\n")
 		}
+
 		prompt.Success("Rit upgraded with success")
 		return nil
 	}

--- a/pkg/credential/settings.go
+++ b/pkg/credential/settings.go
@@ -100,7 +100,6 @@ func formatCredValue(credential string) string {
 			if i > 10 {
 				break
 			}
-			resumedCredential = append(resumedCredential, r)
 		}
 		return string(resumedCredential) + "..."
 	} else {


### PR DESCRIPTION
**- What I did**

Removed an extra append which is causing duplicate letters on list credential command

**- How to verify it**

Use rit list credential

**- Description for the changelog**

list credential duplicated letters fixed