### PR TITLE
Improved CI to avoid 'killed signal' error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,7 @@ workflows:
                 - beta
     jobs:
       - release_creator
+
   nightly:
     triggers:
       - schedule:
@@ -388,6 +389,7 @@ workflows:
                 - master
     jobs:
       - rebase_nightly
+
   beta:
     triggers:
       - schedule:
@@ -436,6 +438,7 @@ workflows:
             <<: *FILTERS_CHECK_CODE
           requires:
             - build-code
+
   release:
     jobs:
       - build:
@@ -482,6 +485,7 @@ workflows:
             <<: *FILTERS_RELEASE
           requires:
             - release-publish
+
   delivery:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ executors:
     docker:
       - image: *PYTHONWITHGO_IMAGE
         user: root
+    resource_class: small
     working_directory: /workspace
 
   ritchie-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ executors:
     docker:
       - image: *PYTHONWITHGO_IMAGE
         user: root
-    resource_class: small
+    resource_class: medium
     working_directory: /workspace
 
   ritchie-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,8 @@ jobs:
       - run:
           name: lint
           command: |
-            golangci-lint run --no-config --issues-exit-code=1 --deadline=10m -v
+            golangci-lint run --no-config --issues-exit-code=1 --timeout=5m -v
+          no_output_timeout: 5m
 
   horus:
     executor: horus-executor
@@ -145,6 +146,7 @@ jobs:
           name: codecov upload
           when: always
           command: bash <(curl -s https://codecov.io/bash)
+
   unix_functional_test:
     executor: ritchie-executor
     environment:


### PR DESCRIPTION
**- What I did**
- Add `resource_class` property in lint job executor

**- How to verify it**
- Check pipeline status

**- Description for the changelog**
- Add "resource_class" property in lint job executor to avoid breaking the pipeline by the "killed signal" error