### PR TITLE
Add column from latest version on list repo command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,7 +190,7 @@ func buildCommands() *cobra.Command {
 	showCtxCmd := cmd.NewShowContextCmd(ctxFinder)
 	addRepoCmd := cmd.NewAddRepoCmd(repoAddLister, repoProviders, inputTextValidator, inputPassword, inputURL, inputList, inputBool, inputInt, tutorialFinder)
 	updateRepoCmd := cmd.NewUpdateRepoCmd(http.DefaultClient, repoListUpdater, repoProviders, inputText, inputPassword, inputURL, inputList, inputBool, inputInt)
-	listRepoCmd := cmd.NewListRepoCmd(repoLister, tutorialFinder)
+	listRepoCmd := cmd.NewListRepoCmd(repoLister, repoProviders, tutorialFinder)
 	deleteRepoCmd := cmd.NewDeleteRepoCmd(repoLister, inputList, repoDeleter)
 	setPriorityCmd := cmd.NewSetPriorityCmd(inputList, inputInt, repoLister, repoPrioritySetter)
 	autocompleteZsh := cmd.NewAutocompleteZsh(autocompleteGen)

--- a/pkg/cmd/list_repo_test.go
+++ b/pkg/cmd/list_repo_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
 )
 
-func Test_listRepoCmd_runFunc(t *testing.T) {
+func TestListRepoRunFunc(t *testing.T) {
 	someError := errors.New("some error")
 	type in struct {
 		RepositoryLister formula.RepositoryLister
@@ -118,7 +118,7 @@ func Test_listRepoCmd_runFunc(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Run with success when tags fail",
+			name: "Run with success when lasted tag fail",
 			in: in{
 				RepositoryLister: RepositoryListerCustomMock{
 					list: func() (formula.Repos, error) {
@@ -134,10 +134,34 @@ func Test_listRepoCmd_runFunc(t *testing.T) {
 				},
 				Tutorial: TutorialFinderMockReturnDisabled{},
 				Repos: GitRepositoryMock{
-					tags: func(info git.RepoInfo) (git.Tags, error) {
-						return git.Tags{git.Tag{Name: "1.0.0"}}, someError
+					latestTag: func(info git.RepoInfo) (git.Tag, error) {
+						return git.Tag{}, someError
 					},
 				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Return err when find tutorial fail",
+			in: in{
+				RepositoryLister: RepositoryListerCustomMock{
+					list: func() (formula.Repos, error) {
+						return formula.Repos{
+							{
+								Name:     "someRepo1",
+								Provider: "Github",
+								Url:      "https://github.com/owner/repo",
+								Token:    "token",
+							},
+						}, nil
+					},
+				},
+				Tutorial: TutorialFindSetterCustomMock{
+					find: func() (rtutorial.TutorialHolder, error) {
+						return rtutorial.TutorialHolder{}, someError
+					},
+				},
+				Repos: defaultGitRepositoryMock,
 			},
 			wantErr: true,
 		},

--- a/pkg/cmd/list_repo_test.go
+++ b/pkg/cmd/list_repo_test.go
@@ -18,18 +18,20 @@ package cmd
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
-	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
+	"github.com/ZupIT/ritchie-cli/pkg/git"
+	"github.com/ZupIT/ritchie-cli/pkg/git/github"
 )
 
 func Test_listRepoCmd_runFunc(t *testing.T) {
-	finderTutorial := rtutorial.NewFinder(os.TempDir(), stream.NewFileManager())
+	repoProviders := formula.NewRepoProviders()
+	repoProviders.Add("Github", formula.Git{Repos: defaultGitRepositoryMock, NewRepoInfo: github.NewRepoInfo})
+
 	type in struct {
 		RepositoryLister formula.RepositoryLister
+		Repos            git.Repositories
 	}
 	tests := []struct {
 		name    string
@@ -43,7 +45,10 @@ func Test_listRepoCmd_runFunc(t *testing.T) {
 					list: func() (formula.Repos, error) {
 						return formula.Repos{
 							{
-								Name: "someRepo1",
+								Name:     "someRepo1",
+								Provider: "Github",
+								Url:      "https://github.com/owner/repo",
+								Token:    "token",
 							},
 						}, nil
 					},
@@ -58,10 +63,16 @@ func Test_listRepoCmd_runFunc(t *testing.T) {
 					list: func() (formula.Repos, error) {
 						return formula.Repos{
 							{
-								Name: "someRepo1",
+								Name:     "someRepo1",
+								Provider: "Github",
+								Url:      "https://github.com/owner/repo1",
+								Token:    "token",
 							},
 							{
-								Name: "someRepo2",
+								Name:     "someRepo2",
+								Provider: "Github",
+								Url:      "https://github.com/owner/repo2",
+								Token:    "token",
 							},
 						}, nil
 					},
@@ -83,7 +94,7 @@ func Test_listRepoCmd_runFunc(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lr := NewListRepoCmd(tt.in.RepositoryLister, finderTutorial)
+			lr := NewListRepoCmd(tt.in.RepositoryLister, repoProviders, TutorialFinderMockReturnDisabled{})
 			lr.PersistentFlags().Bool("stdin", false, "input by stdin")
 			if err := lr.Execute(); (err != nil) != tt.wantErr {
 				t.Errorf("setCredentialCmd_runPrompt() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -414,6 +414,12 @@ func (t TutorialFindSetterCustomMock) Set(tutorial string) (rtutorial.TutorialHo
 	return t.set(tutorial)
 }
 
+type TutorialFinderMockReturnDisabled struct{}
+
+func (TutorialFinderMockReturnDisabled) Find() (rtutorial.TutorialHolder, error) {
+	return rtutorial.TutorialHolder{Current: "disabled"}, nil
+}
+
 type DirManagerCustomMock struct {
 	exists func(dir string) bool
 	list   func(dir string, hiddenDir bool) ([]string, error)

--- a/pkg/formula/repo.go
+++ b/pkg/formula/repo.go
@@ -64,7 +64,6 @@ func (r RepoProvider) String() string {
 type Git struct {
 	Repos       git.Repositories
 	NewRepoInfo func(url string, token string) git.RepoInfo
-	ReposTags   func(repos git.Repositories, repoProviders RepoProviders) []git.RepoInfo
 }
 
 type RepoProviders map[RepoProvider]Git

--- a/pkg/formula/repo.go
+++ b/pkg/formula/repo.go
@@ -64,6 +64,7 @@ func (r RepoProvider) String() string {
 type Git struct {
 	Repos       git.Repositories
 	NewRepoInfo func(url string, token string) git.RepoInfo
+	ReposTags   func(repos git.Repositories, repoProviders RepoProviders) []git.RepoInfo
 }
 
 type RepoProviders map[RepoProvider]Git


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Good morning, good afternoon, good night Ritchiers

In this PR we add a new column (LATEST VERSION) to the repository information in the rit list repo command and change the name of the version column to the "current version".
This column shows the latest version of each repository.

> ![Captura de tela de 2020-09-15 09-36-31](https://user-images.githubusercontent.com/67295691/93211263-5fc17f80-f737-11ea-926c-b4fa4e063502.png)
> When the ritchie cannot find this information (connection) it presents an error message instead.


**- How to verify it**
> Clone this pr with the command
```bash
git fetch upstream pull/518/head:feature/add-list-of-new-tags-to-command-list-repo

```
> And run rit list repo
```bash
git checkout feature/add-list-of-new-tags-to-command-list-repo
make build && cp dist/linux/rit /usr/local/bin/
rit list repo #  Run and see information about available versions
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add column from latest version on list repo command
