### PR TITLE
Displays error when invalid argument added to command

### DIFF
--- a/functional/core/core_feature.json
+++ b/functional/core/core_feature.json
@@ -193,7 +193,7 @@
                 "action": "main"
             }
         ],
-        "result": "Set contexts, credentials and priorities for formula repositories."
+        "result": "Set contexts, credentials, priorities for formula repositories and formulas runner defaults."
     },
     {
         "entry": "Update",
@@ -303,7 +303,7 @@
                 "action": "main"
             }
         ],
-        "result": "Show current context."
+        "result": "Show current context and formula-runnner default"
     },
     {
         "entry": "Create",

--- a/pkg/cmd/add.go
+++ b/pkg/cmd/add.go
@@ -23,9 +23,11 @@ import (
 // NewAddCmd create a new add instance
 func NewAddCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "add SUBCOMMAND",
-		Short:   "Add repositories ",
-		Long:    "Add a new repository of formulas",
-		Example: "rit add repo",
+		Use:       "add SUBCOMMAND",
+		Short:     "Add repositories ",
+		Long:      "Add a new repository of formulas",
+		Example:   "rit add repo",
+		ValidArgs: []string{"repo"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/add_repo.go
+++ b/pkg/cmd/add_repo.go
@@ -68,10 +68,12 @@ func NewAddRepoCmd(
 		rt:                 rtf,
 	}
 	cmd := &cobra.Command{
-		Use:     "repo",
-		Short:   "Add a repository",
-		Example: "rit add repo",
-		RunE:    RunFuncE(addRepo.runStdin(), addRepo.runPrompt()),
+		Use:       "repo",
+		Short:     "Add a repository",
+		Example:   "rit add repo",
+		RunE:      RunFuncE(addRepo.runStdin(), addRepo.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	cmd.LocalFlags()
 

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -44,10 +44,12 @@ func NewAutocompleteCmd() *cobra.Command {
 	shells := strings.Join(supportedShell, ", ")
 
 	return &cobra.Command{
-		Use:     "completion SUBCOMMAND",
-		Short:   "Add autocomplete for terminal (" + shells + ")",
-		Long:    "Add autocomplete for terminal, available for (" + shells + ").",
-		Example: "rit completion zsh",
+		Use:       "completion SUBCOMMAND",
+		Short:     "Add autocomplete for terminal (" + shells + ")",
+		Long:      "Add autocomplete for terminal, available for (" + shells + ").",
+		Example:   "rit completion zsh",
+		ValidArgs: supportedShell,
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 
@@ -70,8 +72,10 @@ To install run:
  $ echo "source ~/.rit_completion" >> ~/.zshrc
 
 `,
-		Example: "rit completion zsh | source",
-		RunE:    a.runFunc(),
+		Example:   "rit completion zsh | source",
+		RunE:      a.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 
@@ -94,8 +98,10 @@ To install run:
  $ echo "source ~/.rit_completion" >> ~/.bashrc
 
 `,
-		Example: "rit completion bash | source",
-		RunE:    a.runFunc(),
+		Example:   "rit completion bash | source",
+		RunE:      a.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 
@@ -117,8 +123,10 @@ To install run:
  $ echo "rit completion fish | source" >> ~/.config/fish/config.fish
 
 `,
-		Example: "rit completion fish | source",
-		RunE:    a.runFunc(),
+		Example:   "rit completion fish | source",
+		RunE:      a.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 
@@ -136,8 +144,10 @@ Only powerShell >= version 5.X is supported
 To install run and after restart powerShell:
 	rit completion powershell >> $PROFILE
 `,
-		Example: "rit completion powershell >> $PROFILE",
-		RunE:    a.runFunc(),
+		Example:   "rit completion powershell >> $PROFILE",
+		RunE:      a.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -20,9 +20,11 @@ import "github.com/spf13/cobra"
 
 func NewBuildCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "build SUB_COMMAND",
-		Short:   "Build formulas",
-		Long:    "Build formula with latest changes.",
-		Example: "rit build formula",
+		Use:       "build SUB_COMMAND",
+		Short:     "Build formulas",
+		Long:      "Build formula with latest changes.",
+		Example:   "rit build formula",
+		ValidArgs: []string{"formula"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/build_formula.go
+++ b/pkg/cmd/build_formula.go
@@ -78,7 +78,9 @@ func NewBuildFormulaCmd(
 		Short: "Build your formulas locally. Use --watch flag and get real-time updates.",
 		Long: `Use this command to build your formulas locally. To make formulas development easier, you can run 
 the command with the --watch flag and get real-time updates.`,
-		RunE: s.runFunc(),
+		RunE:      s.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	cmd.Flags().BoolP("watch", "w", false, "Use this flag to watch your developing formulas")
 

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -23,9 +23,11 @@ import (
 // NewCreateCmd creates new cmd instance
 func NewCreateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "create SUBCOMMAND",
-		Short:   "Create formulas",
-		Long:    "Create a new formula.",
-		Example: "rit create formula",
+		Use:       "create SUBCOMMAND",
+		Short:     "Create formulas",
+		Long:      "Create a new formula.",
+		Example:   "rit create formula",
+		ValidArgs: []string{"formula"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/create_formula.go
+++ b/pkg/cmd/create_formula.go
@@ -77,10 +77,12 @@ func NewCreateFormulaCmd(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "formula",
-		Short:   "Create a new formula",
-		Example: "rit create formula",
-		RunE:    RunFuncE(c.runStdin(), c.runPrompt()),
+		Use:       "formula",
+		Short:     "Create a new formula",
+		Example:   "rit create formula",
+		RunE:      RunFuncE(c.runStdin(), c.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	cmd.LocalFlags()

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -25,7 +25,7 @@ func NewDeleteCmd() *cobra.Command {
 		Short:     "Delete contexts, repositories and formulas.",
 		Long:      "Delete contexts, repositories and formulas.",
 		Example:   "rit delete context",
-		ValidArgs: []string{"context, formula, repo"},
+		ValidArgs: []string{"context", "formula", "repo"},
 		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -21,9 +21,11 @@ import "github.com/spf13/cobra"
 // NewDeleteCmd create a new delete instance
 func NewDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "delete SUBCOMMAND",
-		Short:   "Delete contexts, repositories and formulas.",
-		Long:    "Delete contexts, repositories and formulas.",
-		Example: "rit delete context",
+		Use:       "delete SUBCOMMAND",
+		Short:     "Delete contexts, repositories and formulas.",
+		Long:      "Delete contexts, repositories and formulas.",
+		Example:   "rit delete context",
+		ValidArgs: []string{"context, formula, repo"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/delete_context.go
+++ b/pkg/cmd/delete_context.go
@@ -46,10 +46,12 @@ func NewDeleteContextCmd(
 	d := deleteContextCmd{fr, ib, il}
 
 	cmd := &cobra.Command{
-		Use:     "context",
-		Short:   "Delete context for credentials",
-		Example: "rit delete context",
-		RunE:    RunFuncE(d.runStdin(), d.runPrompt()),
+		Use:       "context",
+		Short:     "Delete context for credentials",
+		Example:   "rit delete context",
+		RunE:      RunFuncE(d.runStdin(), d.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	cmd.LocalFlags()

--- a/pkg/cmd/delete_formula.go
+++ b/pkg/cmd/delete_formula.go
@@ -88,10 +88,12 @@ func NewDeleteFormulaCmd(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "formula",
-		Short:   "Delete specific formula",
-		Example: "rit delete formula",
-		RunE:    RunFuncE(d.runStdin(), d.runPrompt()),
+		Use:       "formula",
+		Short:     "Delete specific formula",
+		Example:   "rit delete formula",
+		RunE:      RunFuncE(d.runStdin(), d.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	return cmd

--- a/pkg/cmd/delete_repo.go
+++ b/pkg/cmd/delete_repo.go
@@ -40,10 +40,12 @@ type deleteRepoCmd struct {
 func NewDeleteRepoCmd(rl formula.RepositoryLister, il prompt.InputList, rd formula.RepositoryDeleter) *cobra.Command {
 	dr := deleteRepoCmd{rl, il, rd}
 	cmd := &cobra.Command{
-		Use:     "repo",
-		Short:   "Delete a repository",
-		Example: "rit delete repo",
-		RunE:    RunFuncE(dr.runStdin(), dr.runFunc()),
+		Use:       "repo",
+		Short:     "Delete a repository",
+		Example:   "rit delete repo",
+		RunE:      RunFuncE(dr.runStdin(), dr.runFunc()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	return cmd
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -92,10 +92,12 @@ func NewInitCmd(
 	o := initCmd{repo: repo, git: git, tutorial: tutorial, config: config, file: file, InputList: inList, InputBool: inBool}
 
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize rit configuration",
-		Long:  "Initialize rit configuration",
-		RunE:  RunFuncE(o.runStdin(), o.runPrompt()),
+		Use:       "init",
+		Short:     "Initialize rit configuration",
+		Long:      "Initialize rit configuration",
+		RunE:      RunFuncE(o.runStdin(), o.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	return cmd

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -27,9 +27,11 @@ It can be used to list repositories or credentials.
 // NewListCmd create a new list instance
 func NewListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "list SUBCOMMAND",
-		Short:   "List repositories or credentials",
-		Long:    descListLong,
-		Example: "rit list repo, rit list credential",
+		Use:       "list SUBCOMMAND",
+		Short:     "List repositories or credentials",
+		Long:      descListLong,
+		Example:   "rit list repo, rit list credential",
+		ValidArgs: []string{"credential", "repo"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/list_credential.go
+++ b/pkg/cmd/list_credential.go
@@ -34,10 +34,12 @@ func NewListCredentialCmd(ss credential.ReaderWriterPather) *cobra.Command {
 	l := &listCredentialCmd{ss}
 
 	cmd := &cobra.Command{
-		Use:     "credential",
-		Short:   "List credentials fields and part of values",
-		Example: "rit list credential",
-		RunE:    l.run(),
+		Use:       "credential",
+		Short:     "List credentials fields and part of values",
+		Example:   "rit list credential",
+		RunE:      l.run(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	return cmd

--- a/pkg/cmd/list_repo.go
+++ b/pkg/cmd/list_repo.go
@@ -40,10 +40,12 @@ type listRepoCmd struct {
 func NewListRepoCmd(rl formula.RepositoryLister, rtf rtutorial.Finder) *cobra.Command {
 	lr := listRepoCmd{rl, rtf}
 	cmd := &cobra.Command{
-		Use:     "repo",
-		Short:   "Show a list with all your available repositories",
-		Example: "rit list repo",
-		RunE:    lr.runFunc(),
+		Use:       "repo",
+		Short:     "Show a list with all your available repositories",
+		Example:   "rit list repo",
+		RunE:      lr.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	return cmd
 }

--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -20,10 +20,12 @@ func NewMetricsCmd(file stream.FileWriteReadExister, inList prompt.InputList) *c
 	}
 
 	cmd := &cobra.Command{
-		Use:   "metrics",
-		Short: "Turn metrics on and off",
-		Long:  "Stop or start to send anonymous metrics to ritchie team.",
-		RunE:  m.run(),
+		Use:       "metrics",
+		Short:     "Turn metrics on and off",
+		Long:      "Stop or start to send anonymous metrics to ritchie team.",
+		RunE:      m.run(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	return cmd

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -98,6 +98,8 @@ func NewRootCmd(
 		RunE:               runHelp,
 		SilenceErrors:      true,
 		TraverseChildren:   true,
+		ValidArgs:          []string{""},
+		Args:               cobra.OnlyValidArgs,
 	}
 	cmd.PersistentFlags().Bool("stdin", false, "input by stdin")
 	return cmd

--- a/pkg/cmd/set.go
+++ b/pkg/cmd/set.go
@@ -23,9 +23,11 @@ import (
 // NewSetCmd creates new cmd instance
 func NewSetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "set SUBCOMMAND",
-		Short:   "Set contexts, credentials and priorities",
-		Long:    "Set contexts, credentials and priorities for formula repositories.",
-		Example: "rit set context",
+		Use:       "set SUBCOMMAND",
+		Short:     "Set contexts, credentials, repositories priorities and formulas runner defaults.",
+		Long:      "Set contexts, credentials, priorities for formula repositories and formulas runner defaults.",
+		Example:   "rit set context",
+		ValidArgs: []string{"context", "credential", "formula-runner", "repo-priority"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/set_context.go
+++ b/pkg/cmd/set_context.go
@@ -47,10 +47,12 @@ func NewSetContextCmd(
 	s := setContextCmd{fs, it, il}
 
 	cmd := &cobra.Command{
-		Use:     "context",
-		Short:   "Set context",
-		Example: "rit set context",
-		RunE:    RunFuncE(s.runStdin(), s.runPrompt()),
+		Use:       "context",
+		Short:     "Set context",
+		Example:   "rit set context",
+		RunE:      RunFuncE(s.runStdin(), s.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	cmd.LocalFlags()

--- a/pkg/cmd/set_credential.go
+++ b/pkg/cmd/set_credential.go
@@ -64,10 +64,12 @@ func NewSetCredentialCmd(
 	}
 
 	cmd := &cobra.Command{
-		Use:   "credential",
-		Short: "Set credential",
-		Long:  `Set credentials for Github, Gitlab, AWS, UserPass, etc.`,
-		RunE:  RunFuncE(s.runStdin(), s.runPrompt()),
+		Use:       "credential",
+		Short:     "Set credential",
+		Long:      `Set credentials for Github, Gitlab, AWS, UserPass, etc.`,
+		RunE:      RunFuncE(s.runStdin(), s.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	cmd.LocalFlags()
 	return cmd

--- a/pkg/cmd/set_formula_runner.go
+++ b/pkg/cmd/set_formula_runner.go
@@ -33,10 +33,12 @@ func NewSetFormulaRunnerCmd(c formula.ConfigRunner, i prompt.InputList) *cobra.C
 	s := setFormulaRunnerCmd{c, i}
 
 	return &cobra.Command{
-		Use:     "formula-runner",
-		Short:   "Set the default formula runner",
-		Example: "rit set formula-runner",
-		RunE:    RunFuncE(s.runStdin(), s.runPrompt()),
+		Use:       "formula-runner",
+		Short:     "Set the default formula runner",
+		Example:   "rit set formula-runner",
+		RunE:      RunFuncE(s.runStdin(), s.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 

--- a/pkg/cmd/set_priority.go
+++ b/pkg/cmd/set_priority.go
@@ -50,10 +50,12 @@ func NewSetPriorityCmd(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "repo-priority",
-		Short:   "Set a repository priority",
-		Example: "rit set repo-priority",
-		RunE:    s.runFunc(),
+		Use:       "repo-priority",
+		Short:     "Set a repository priority",
+		Example:   "rit set repo-priority",
+		RunE:      s.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	return cmd

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -20,9 +20,11 @@ import "github.com/spf13/cobra"
 
 func NewShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "show SUB_COMMAND",
-		Short:   "Show context",
-		Long:    "Show current context.",
-		Example: "rit show context",
+		Use:       "show SUB_COMMAND",
+		Short:     "Show context and formula-runnner default",
+		Long:      "Show current context and formula-runnner default",
+		Example:   "rit show context",
+		ValidArgs: []string{"context", "formula-runner"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/show_context.go
+++ b/pkg/cmd/show_context.go
@@ -33,10 +33,12 @@ func NewShowContextCmd(f rcontext.Finder) *cobra.Command {
 	s := showContextCmd{f}
 
 	return &cobra.Command{
-		Use:     "context",
-		Short:   "Show current context",
-		Example: "rit show context",
-		RunE:    s.runFunc(),
+		Use:       "context",
+		Short:     "Show current context",
+		Example:   "rit show context",
+		RunE:      s.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 

--- a/pkg/cmd/show_formula_runner.go
+++ b/pkg/cmd/show_formula_runner.go
@@ -33,10 +33,12 @@ func NewShowFormulaRunnerCmd(c formula.ConfigRunner) *cobra.Command {
 	s := showFormulaRunnerCmd{c}
 
 	return &cobra.Command{
-		Use:     "formula-runner",
-		Short:   "Show the default formula runner",
-		Example: "rit show formula-runner",
-		RunE:    s.runFunc(),
+		Use:       "formula-runner",
+		Short:     "Show the default formula runner",
+		Example:   "rit show formula-runner",
+		RunE:      s.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 

--- a/pkg/cmd/tutorial.go
+++ b/pkg/cmd/tutorial.go
@@ -41,10 +41,12 @@ func NewTutorialCmd(homePath string, il prompt.InputList, fs rtutorial.FindSette
 	o := tutorialCmd{homePath, il, fs}
 
 	cmd := &cobra.Command{
-		Use:   "tutorial",
-		Short: "Enable or disable the tutorial",
-		Long:  "Enable or disable the tutorial",
-		RunE:  RunFuncE(o.runStdin(), o.runPrompt()),
+		Use:       "tutorial",
+		Short:     "Enable or disable the tutorial",
+		Long:      "Enable or disable the tutorial",
+		RunE:      RunFuncE(o.runStdin(), o.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 
 	cmd.LocalFlags()

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -21,9 +21,11 @@ import "github.com/spf13/cobra"
 // NewUpdateCmd create a new update instance
 func NewUpdateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "update SUBCOMMAND",
-		Short:   "Update repositories",
-		Long:    "Update repositories.",
-		Example: "rit update repo",
+		Use:       "update SUBCOMMAND",
+		Short:     "Update repositories",
+		Long:      "Update repositories.",
+		Example:   "rit update repo",
+		ValidArgs: []string{"repo"},
+		Args:      cobra.OnlyValidArgs,
 	}
 }

--- a/pkg/cmd/update_repo.go
+++ b/pkg/cmd/update_repo.go
@@ -68,10 +68,12 @@ func NewUpdateRepoCmd(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "repo",
-		Short:   "Update a repository.",
-		Example: "rit update repo",
-		RunE:    RunFuncE(updateRepo.runStdin(), updateRepo.runPrompt()),
+		Use:       "repo",
+		Short:     "Update a repository.",
+		Example:   "rit update repo",
+		RunE:      RunFuncE(updateRepo.runStdin(), updateRepo.runPrompt()),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 	cmd.LocalFlags()
 

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -53,10 +53,12 @@ func NewUpgradeCmd(
 	}
 
 	return &cobra.Command{
-		Use:   "upgrade",
-		Short: "Update rit version",
-		Long:  `Update rit version to last stable version.`,
-		RunE:  u.runFunc(),
+		Use:       "upgrade",
+		Short:     "Update rit version",
+		Long:      `Update rit version to last stable version.`,
+		RunE:      u.runFunc(),
+		ValidArgs: []string{""},
+		Args:      cobra.OnlyValidArgs,
 	}
 }
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**

Added validation of arguments in commands, commands 'leaf' (don't have subcommands) presents an error when other arguments are informed.

> ![aa](https://user-images.githubusercontent.com/67295691/93476431-2a03ce80-f8d0-11ea-9463-307f6074aa06.png)

**- How to verify it**
> Clone this pr with the command
```bash
git fetch upstream pull/530/head:fix/displays-error-when-invalid-argument-added-to-command

```
> And run commands with invalid arguments
```bash
git checkout fix/displays-error-when-invalid-argument-added-to-command
make build && cp dist/linux/rit /usr/local/bin/

rit list repo ritchie #  Run and see error
rit list repo #  Run

rit list # Run and see the suggestions
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Displays error when invalid argument added to command