### PR TITLE
Add support to the tutorial field in config.json

### DIFF
--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -135,19 +135,19 @@ func (autocompleteGenMock) Generate(s autocomplete.ShellName, cmd *cobra.Command
 
 type inputTrueMock struct{}
 
-func (inputTrueMock) Bool(name string, items []string) (bool, error) {
+func (inputTrueMock) Bool(name string, items []string, helper ...string) (bool, error) {
 	return true, nil
 }
 
 type inputFalseMock struct{}
 
-func (inputFalseMock) Bool(name string, items []string) (bool, error) {
+func (inputFalseMock) Bool(name string, items []string, helper ...string) (bool, error) {
 	return false, nil
 }
 
 type inputBoolErrorMock struct{}
 
-func (inputBoolErrorMock) Bool(name string, items []string) (bool, error) {
+func (inputBoolErrorMock) Bool(name string, items []string, helper ...string) (bool, error) {
 	return false, errors.New("error on boolean list")
 }
 

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -117,13 +117,13 @@ func (inputIntErrorMock) Int(name string, helper ...string) (int64, error) {
 
 type inputPasswordMock struct{}
 
-func (inputPasswordMock) Password(label string) (string, error) {
+func (inputPasswordMock) Password(label string, helper ...string) (string, error) {
 	return "s3cr3t", nil
 }
 
 type inputPasswordErrorMock struct{}
 
-func (inputPasswordErrorMock) Password(label string) (string, error) {
+func (inputPasswordErrorMock) Password(label string, helper ...string) (string, error) {
 	return "", errors.New("password error")
 }
 

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -153,7 +153,7 @@ func (inputBoolErrorMock) Bool(name string, items []string, helper ...string) (b
 
 type inputListMock struct{}
 
-func (inputListMock) List(name string, items []string) (string, error) {
+func (inputListMock) List(name string, items []string, helper ...string) (string, error) {
 	return "item-mocked", nil
 }
 
@@ -161,13 +161,13 @@ type inputListCustomMock struct {
 	list func(name string, items []string) (string, error)
 }
 
-func (m inputListCustomMock) List(name string, items []string) (string, error) {
+func (m inputListCustomMock) List(name string, items []string, helper ...string) (string, error) {
 	return m.list(name, items)
 }
 
 type inputListErrorMock struct{}
 
-func (inputListErrorMock) List(name string, items []string) (string, error) {
+func (inputListErrorMock) List(name string, items []string, helper ...string) (string, error) {
 	return "item-mocked", errors.New("some error")
 }
 

--- a/pkg/env/envcredential/env_credential_test.go
+++ b/pkg/env/envcredential/env_credential_test.go
@@ -74,6 +74,6 @@ type passwordMock struct {
 	value string
 }
 
-func (pass passwordMock) Password(string) (string, error) {
+func (pass passwordMock) Password(string, ...string) (string, error) {
 	return pass.value, nil
 }

--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -49,6 +49,7 @@ type (
 		Items     []string  `json:"items"`
 		Cache     Cache     `json:"cache"`
 		Condition Condition `json:"condition"`
+		Tutorial  string    `json:"tutorial"`
 	}
 
 	Cache struct {

--- a/pkg/formula/runner/docker/runner_test.go
+++ b/pkg/formula/runner/docker/runner_test.go
@@ -238,7 +238,7 @@ func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 
-func (i inputMock) Password(string) (string, error) {
+func (i inputMock) Password(string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/formula/runner/docker/runner_test.go
+++ b/pkg/formula/runner/docker/runner_test.go
@@ -234,7 +234,7 @@ func (i inputMock) Text(string, bool, ...string) (string, error) {
 	return i.text, i.err
 }
 
-func (i inputMock) Bool(string, []string) (bool, error) {
+func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 

--- a/pkg/formula/runner/docker/runner_test.go
+++ b/pkg/formula/runner/docker/runner_test.go
@@ -226,7 +226,7 @@ type inputMock struct {
 	err     error
 }
 
-func (i inputMock) List(string, []string) (string, error) {
+func (i inputMock) List(string, []string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -142,7 +142,7 @@ func (in InputManager) fromPrompt(cmd *exec.Cmd, setup formula.Setup) error {
 				}
 			}
 		case "bool":
-			valBool, err = in.Bool(input.Label, items)
+			valBool, err = in.Bool(input.Label, items, input.Tutorial)
 			inputVal = strconv.FormatBool(valBool)
 		case "password":
 			inputVal, err = in.Password(input.Label)

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -145,7 +145,7 @@ func (in InputManager) fromPrompt(cmd *exec.Cmd, setup formula.Setup) error {
 			valBool, err = in.Bool(input.Label, items, input.Tutorial)
 			inputVal = strconv.FormatBool(valBool)
 		case "password":
-			inputVal, err = in.Password(input.Label)
+			inputVal, err = in.Password(input.Label, input.Tutorial)
 		default:
 			inputVal, err = in.resolveIfReserved(input)
 		}

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -135,7 +135,8 @@ func (in InputManager) fromPrompt(cmd *exec.Cmd, setup formula.Setup) error {
 				inputVal, err = in.loadInputValList(items, input)
 			} else {
 				validate := input.Default == ""
-				inputVal, err = in.Text(input.Label, validate)
+				inputVal, err = in.Text(input.Label, validate, input.Tutorial)
+
 				if inputVal == "" {
 					inputVal = input.Default
 				}

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -207,10 +207,10 @@ func (in InputManager) loadInputValList(items []string, input formula.Input) (st
 		}
 		items = append(items, newLabel)
 	}
-	inputVal, err := in.List(input.Label, items)
+	inputVal, err := in.List(input.Label, items, input.Tutorial)
 	if inputVal == newLabel {
 		validate := len(input.Default) == 0
-		inputVal, err = in.Text(input.Label, validate)
+		inputVal, err = in.Text(input.Label, validate, input.Tutorial)
 		if len(inputVal) == 0 {
 			inputVal = input.Default
 		}

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -43,7 +43,8 @@ func TestInputManager_Inputs(t *testing.T) {
             "active": true,
             "qty": 6,
             "newLabel": "Type new value. "
-        }
+        },
+		"tutorial": "Add a text for this field."
     },
  	{
         "name": "sample_text",
@@ -66,7 +67,8 @@ func TestInputManager_Inputs(t *testing.T) {
             "qty": 3,
             "newLabel": "Type new value?"
         },
-        "label": "Pick your : "
+        "label": "Pick your : ",
+		"tutorial": "Select an item for this field."
     },
     {
         "name": "sample_bool",
@@ -76,12 +78,14 @@ func TestInputManager_Inputs(t *testing.T) {
             "false",
             "true"
         ],
-        "label": "Pick: "
+        "label": "Pick: ",
+		"tutorial": "Select true or false for this field."
     },
     {
         "name": "sample_password",
         "type": "password",
-        "label": "Pick: "
+        "label": "Pick: ",
+		"tutorial": "Add a secret password for this field."
     },
     {
         "name": "test_resolver",

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -434,7 +434,7 @@ type inputMock struct {
 	err     error
 }
 
-func (i inputMock) List(string, []string) (string, error) {
+func (i inputMock) List(string, []string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -442,7 +442,7 @@ func (i inputMock) Text(string, bool, ...string) (string, error) {
 	return i.text, i.err
 }
 
-func (i inputMock) Bool(string, []string) (bool, error) {
+func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -446,7 +446,7 @@ func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 
-func (i inputMock) Password(string) (string, error) {
+func (i inputMock) Password(string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/formula/runner/local/runner_test.go
+++ b/pkg/formula/runner/local/runner_test.go
@@ -207,7 +207,7 @@ func (i inputMock) Text(string, bool, ...string) (string, error) {
 	return i.text, i.err
 }
 
-func (i inputMock) Bool(string, []string) (bool, error) {
+func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 

--- a/pkg/formula/runner/local/runner_test.go
+++ b/pkg/formula/runner/local/runner_test.go
@@ -211,7 +211,7 @@ func (i inputMock) Bool(string, []string, ...string) (bool, error) {
 	return i.boolean, i.err
 }
 
-func (i inputMock) Password(string) (string, error) {
+func (i inputMock) Password(string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/formula/runner/local/runner_test.go
+++ b/pkg/formula/runner/local/runner_test.go
@@ -199,7 +199,7 @@ type inputMock struct {
 	err     error
 }
 
-func (i inputMock) List(string, []string) (string, error) {
+func (i inputMock) List(string, []string, ...string) (string, error) {
 	return i.text, i.err
 }
 

--- a/pkg/prompt/bool.go
+++ b/pkg/prompt/bool.go
@@ -30,12 +30,17 @@ func NewSurveyBool() SurveyBool {
 	return SurveyBool{}
 }
 
-func (SurveyBool) Bool(name string, items []string) (bool, error) {
+func (SurveyBool) Bool(name string, items []string, helper ...string) (bool, error) {
 	choice := ""
 	prompt := &survey.Select{
 		Message: name,
 		Options: items,
 	}
+
+	if len(helper) > 0 {
+		prompt.Help = helper[0]
+	}
+
 	if err := survey.AskOne(prompt, &choice); err != nil {
 		return false, err
 	}

--- a/pkg/prompt/list.go
+++ b/pkg/prompt/list.go
@@ -27,12 +27,17 @@ func NewSurveyList() SurveyList {
 }
 
 // List show a prompt with options and parse to string.
-func (SurveyList) List(name string, items []string) (string, error) {
+func (SurveyList) List(name string, items []string, helper ...string) (string, error) {
 	choice := ""
 	prompt := &survey.Select{
 		Message: name,
 		Options: items,
 	}
+
+	if len(helper) > 0 {
+		prompt.Help = helper[0]
+	}
+
 	if err := survey.AskOne(prompt, &choice); err != nil {
 		return "", err
 	}

--- a/pkg/prompt/password.go
+++ b/pkg/prompt/password.go
@@ -28,10 +28,14 @@ func NewSurveyPassword() SurveyPassword {
 	return SurveyPassword{}
 }
 
-func (SurveyPassword) Password(label string) (string, error) {
+func (SurveyPassword) Password(label string, helper ...string) (string, error) {
 	password := ""
 	prompt := &survey.Password{
 		Message: label,
+	}
+
+	if len(helper) > 0 {
+		prompt.Help = helper[0]
 	}
 
 	return password, survey.AskOne(prompt, &password)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -29,7 +29,7 @@ type InputBool interface {
 }
 
 type InputPassword interface {
-	Password(label string) (string, error)
+	Password(label string, helper ...string) (string, error)
 }
 
 type InputMultiline interface {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -37,7 +37,7 @@ type InputMultiline interface {
 }
 
 type InputList interface {
-	List(name string, items []string) (string, error)
+	List(name string, items []string, helper ...string) (string, error)
 }
 
 type InputInt interface {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -25,7 +25,7 @@ type InputTextValidator interface {
 }
 
 type InputBool interface {
-	Bool(name string, items []string) (bool, error)
+	Bool(name string, items []string, helper ...string) (bool, error)
 }
 
 type InputPassword interface {


### PR DESCRIPTION
**- What I did**
- I added support to the tutorial field in config.json
Example:
```json
[
  {
    "name": "sample_text",
    "type": "text",
    "label": "Type : ",
    "cache": {
      "active": true,
      "qty": 6,
      "newLabel": "Type new value. "
    },
    "tutorial": "Add a text for this field."
  },
  {
    "name": "sample_text",
    "type": "text",
    "label": "Type : ",
    "default": "test"
  },
  {
    "name": "sample_list",
    "type": "text",
    "default": "in1",
    "items": [
      "in_list1",
      "in_list2",
      "in_list3",
      "in_listN"
    ],
    "cache": {
      "active": true,
      "qty": 3,
      "newLabel": "Type new value?"
    },
    "label": "Pick your : ",
    "tutorial": "Select an item for this field."
  },
  {
    "name": "sample_bool",
    "type": "bool",
    "default": "false",
    "items": [
      "false",
      "true"
    ],
    "label": "Pick: ",
    "tutorial": "Select true or false for this field."
  },
  {
    "name": "sample_password",
    "type": "password",
    "label": "Pick: ",
    "tutorial": "Add a secret password for this field."
  }
]
``` 

**- How to verify it**
You can build this branch and add in the config.json the **tutorial** field.

**- Description for the changelog**
Support to the tutorial field in config.json
