### PR TITLE
Remove the ritchie path from the metricId

### DIFF
--- a/pkg/metric/data_collector.go
+++ b/pkg/metric/data_collector.go
@@ -76,7 +76,6 @@ func (d DataCollectorManager) Collect(commandExecutionTime float64, ritVersion s
 		Timestamp:  time.Now(),
 		Data:       data,
 	}
-
 	return metric, nil
 }
 
@@ -97,6 +96,6 @@ func (d DataCollectorManager) repoData() formula.Repo {
 
 func metricID() string {
 	args := os.Args
+	args[0] = "rit"
 	return strings.Join(args, "_")
-
 }


### PR DESCRIPTION
**- What I did**

- Remove the `ritchie path` from the **metricId** when the user uses `PowerShell`

**- How to verify it**

- Access the ritchie metrics dashboard

**- Description for the changelog**

- Remove the `ritchie path` from the **metricId** when the user uses `PowerShell`
