### PR TITLE
Default tree refactoring to use file manager of package stream

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,7 +125,7 @@ func buildCommands() *cobra.Command {
 	ctxFindRemover := rcontext.NewFindRemover(ritchieHomeDir, ctxFinder, ctxRemover)
 	credSetter := credential.NewSetter(ritchieHomeDir, ctxFinder)
 	credFinder := credential.NewFinder(ritchieHomeDir, ctxFinder, fileManager)
-	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds)
+	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds, fileManager)
 	credSettings := credential.NewSettings(fileManager, dirManager, userHomeDir)
 	autocompleteGen := autocomplete.NewGenerator(treeManager)
 	credResolver := envcredential.NewResolver(credFinder, credSetter, inputPassword)

--- a/pkg/autocomplete/generator_test.go
+++ b/pkg/autocomplete/generator_test.go
@@ -32,6 +32,16 @@ func (repoListerMock) List() (formula.Repos, error) {
 	return formula.Repos{}, nil
 }
 
+type FileReadExisterMock struct{}
+
+func (m FileReadExisterMock) Read(path string) ([]byte, error) {
+	return []byte("some data"), nil
+}
+
+func (m FileReadExisterMock) Exists(path string) bool {
+	return false
+}
+
 func TestGenerate(t *testing.T) {
 	type in struct {
 		shell ShellName
@@ -41,7 +51,7 @@ func TestGenerate(t *testing.T) {
 		err error
 	}
 
-	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.Commands{})
+	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.Commands{}, FileReadExisterMock{})
 	autocomplete := NewGenerator(treeMan)
 
 	tests := []struct {

--- a/pkg/formula/creator/creator_test.go
+++ b/pkg/formula/creator/creator_test.go
@@ -52,7 +52,7 @@ func TestCreator(t *testing.T) {
 	_ = dirManager.Remove(resultDir)
 	_ = dirManager.Create(resultDir)
 
-	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.CoreCmds)
+	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.CoreCmds, FileReadExisterMock{})
 
 	tplM := template.NewManager("../../../testdata", dirManager)
 
@@ -197,4 +197,14 @@ type repoListerMock struct{}
 
 func (repoListerMock) List() (formula.Repos, error) {
 	return formula.Repos{}, nil
+}
+
+type FileReadExisterMock struct{}
+
+func (m FileReadExisterMock) Read(path string) ([]byte, error) {
+	return []byte("some data"), nil
+}
+
+func (m FileReadExisterMock) Exists(path string) bool {
+	return false
 }

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tree
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZupIT/ritchie-cli/pkg/api"
+	"github.com/ZupIT/ritchie-cli/pkg/formula"
+	"github.com/ZupIT/ritchie-cli/pkg/formula/builder"
+	"github.com/ZupIT/ritchie-cli/pkg/git"
+	"github.com/ZupIT/ritchie-cli/pkg/git/github"
+	"github.com/ZupIT/ritchie-cli/pkg/stream"
+	"github.com/ZupIT/ritchie-cli/pkg/stream/streams"
+)
+
+var (
+	tmpDir  = os.TempDir()
+	ritHome = filepath.Join(tmpDir, ".rit-tree")
+
+	defaultGitRepositoryMock = GitRepositoryMock{
+		latestTag: func(info git.RepoInfo) (git.Tag, error) {
+			return git.Tag{}, nil
+		},
+		tags: func(info git.RepoInfo) (git.Tags, error) {
+			return git.Tags{git.Tag{Name: "1.0.0"}}, nil
+		},
+		zipball: func(info git.RepoInfo, version string) (io.ReadCloser, error) {
+			return nil, nil
+		},
+	}
+)
+
+func TestMergedTree(t *testing.T) {
+	defer os.Remove(ritHome)
+
+	fileManager := stream.NewFileManager()
+	dirManager := stream.NewDirManager(fileManager)
+
+	workspacePath := filepath.Join(ritHome, "repos", "someRepo1")
+	_ = dirManager.Remove(workspacePath)
+	_ = dirManager.Create(workspacePath)
+	defer os.Remove(workspacePath)
+
+	formulaPath := filepath.Join(ritHome, "repos", "someRepo1", "testing", "formula")
+
+	zipFile := filepath.Join("..", "..", "..", "testdata", "ritchie-formulas-test.zip")
+	_ = streams.Unzip(zipFile, workspacePath)
+
+	defaultTreeManager := NewGenerator(dirManager, fileManager)
+	builderManager := builder.NewBuildLocal(ritHome, dirManager, fileManager, defaultTreeManager)
+	_ = builderManager.Build(workspacePath, formulaPath)
+
+	repoLister := repositoryListerCustomMock{
+		list: func() (formula.Repos, error) {
+			return formula.Repos{
+				{
+					Name:     "someRepo1",
+					Provider: "Github",
+					Url:      "https://github.com/owner/repo",
+					Token:    "token",
+				},
+			}, nil
+		},
+	}
+
+	githubRepo := github.NewRepoManager(http.DefaultClient)
+	repoProviders := formula.NewRepoProviders()
+	repoProviders.Add("Github", formula.Git{Repos: githubRepo, NewRepoInfo: github.NewRepoInfo})
+
+	newTree := NewTreeManager(ritHome, repoLister, api.CoreCmds)
+	mergedTree := newTree.MergedTree(true)
+
+	nullTree := formula.Tree{Commands: []api.Command{}}
+	if len(mergedTree.Commands) == len(nullTree.Commands) {
+		t.Errorf("NewTreeManager_MergedTree() mergedTree = %v", mergedTree)
+	}
+}
+
+type repositoryListerCustomMock struct {
+	list func() (formula.Repos, error)
+}
+
+func (m repositoryListerCustomMock) List() (formula.Repos, error) {
+	return m.list()
+}
+
+type GitRepositoryMock struct {
+	zipball   func(info git.RepoInfo, version string) (io.ReadCloser, error)
+	tags      func(info git.RepoInfo) (git.Tags, error)
+	latestTag func(info git.RepoInfo) (git.Tag, error)
+}
+
+func (m GitRepositoryMock) Zipball(info git.RepoInfo, version string) (io.ReadCloser, error) {
+	return m.zipball(info, version)
+}
+
+func (m GitRepositoryMock) Tags(info git.RepoInfo) (git.Tags, error) {
+	return m.tags(info)
+}
+
+func (m GitRepositoryMock) LatestTag(info git.RepoInfo) (git.Tag, error) {
+	return m.latestTag(info)
+}

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -106,7 +106,7 @@ func TestMergedTree(t *testing.T) {
 	repoProviders := formula.NewRepoProviders()
 	repoProviders.Add("Github", formula.Git{Repos: githubRepo, NewRepoInfo: github.NewRepoInfo})
 
-	fileManager := FileReadExist{
+	fileManager := FileReadExisterMock{
 		exists: func(path string) bool {
 			isLocalRepo := strings.Contains(path, "/local/tree.json")
 			isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
@@ -169,7 +169,7 @@ func TestTree(t *testing.T) {
 
 	type in struct {
 		repo formula.RepositoryLister
-		file FileReadExist
+		file FileReadExisterMock
 	}
 
 	tests := []struct {
@@ -193,7 +193,7 @@ func TestTree(t *testing.T) {
 						}, nil
 					},
 				},
-				file: FileReadExist{
+				file: FileReadExisterMock{
 					exists: func(path string) bool {
 						if strings.Contains(path, "/someRepo/tree.json") {
 							return true
@@ -219,7 +219,7 @@ func TestTree(t *testing.T) {
 						return formula.Repos{}, errFoo
 					},
 				},
-				file: FileReadExist{
+				file: FileReadExisterMock{
 					exists: func(path string) bool {
 						return false
 					},
@@ -239,7 +239,7 @@ func TestTree(t *testing.T) {
 						return formula.Repos{}, errFoo
 					},
 				},
-				file: FileReadExist{
+				file: FileReadExisterMock{
 					exists: func(path string) bool {
 						return true
 					},
@@ -259,7 +259,7 @@ func TestTree(t *testing.T) {
 						return formula.Repos{}, errFoo
 					},
 				},
-				file: FileReadExist{
+				file: FileReadExisterMock{
 					exists: func(path string) bool {
 						return true
 					},
@@ -284,7 +284,7 @@ func TestTree(t *testing.T) {
 							}}, nil
 					},
 				},
-				file: FileReadExist{
+				file: FileReadExisterMock{
 					exists: func(path string) bool {
 						if strings.Contains(path, "/someRepo/tree.json") {
 							return true
@@ -385,15 +385,15 @@ func (m repositoryListerCustomMock) List() (formula.Repos, error) {
 	return m.list()
 }
 
-type FileReadExist struct {
+type FileReadExisterMock struct {
 	read   func(path string) ([]byte, error)
 	exists func(path string) bool
 }
 
-func (m FileReadExist) Read(path string) ([]byte, error) {
+func (m FileReadExisterMock) Read(path string) ([]byte, error) {
 	return m.read(path)
 }
 
-func (m FileReadExist) Exists(path string) bool {
+func (m FileReadExisterMock) Exists(path string) bool {
 	return m.exists(path)
 }

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -95,6 +95,29 @@ func TestMergedTree(t *testing.T) {
 	}
 }
 
+func TestTree(t *testing.T) {
+	defer os.Remove(ritHome)
+
+	repoLister := repositoryListerCustomMock{
+		list: func() (formula.Repos, error) {
+			return formula.Repos{}, nil
+		},
+	}
+
+	newTree := NewTreeManager(ritHome, repoLister, api.CoreCmds)
+	tree, err := newTree.Tree()
+
+	trees := make(map[string]formula.Tree)
+	trees[core] = formula.Tree{Commands: api.CoreCmds}
+	if len(tree) == len(trees) {
+		t.Errorf("NewTreeManager_Tree() tree = %v", tree)
+	}
+
+	if err != nil {
+		t.Errorf("NewTreeManager_Tree() error = %v", err)
+	}
+}
+
 type repositoryListerCustomMock struct {
 	list func() (formula.Repos, error)
 }

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -18,7 +18,6 @@ package tree
 
 import (
 	"errors"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -27,7 +26,6 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/api"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
 	"github.com/ZupIT/ritchie-cli/pkg/formula/builder"
-	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/git/github"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
 	"github.com/ZupIT/ritchie-cli/pkg/stream/streams"
@@ -36,20 +34,6 @@ import (
 var (
 	tmpDir  = os.TempDir()
 	ritHome = filepath.Join(tmpDir, ".rit-tree")
-
-	defaultGitRepositoryMock = GitRepositoryMock{
-		latestTag: func(info git.RepoInfo) (git.Tag, error) {
-			return git.Tag{}, nil
-		},
-		tags: func(info git.RepoInfo) (git.Tags, error) {
-			return git.Tags{git.Tag{Name: "1.0.0"}}, nil
-		},
-		zipball: func(info git.RepoInfo, version string) (io.ReadCloser, error) {
-			return nil, nil
-		},
-	}
-
-	errFoo = errors.New("some error")
 )
 
 func TestMergedTree(t *testing.T) {
@@ -100,6 +84,7 @@ func TestMergedTree(t *testing.T) {
 
 func TestTree(t *testing.T) {
 	defer os.Remove(ritHome)
+	errFoo := errors.New("some error")
 
 	type in struct {
 		repo formula.RepositoryLister
@@ -158,22 +143,4 @@ type repositoryListerCustomMock struct {
 
 func (m repositoryListerCustomMock) List() (formula.Repos, error) {
 	return m.list()
-}
-
-type GitRepositoryMock struct {
-	zipball   func(info git.RepoInfo, version string) (io.ReadCloser, error)
-	tags      func(info git.RepoInfo) (git.Tags, error)
-	latestTag func(info git.RepoInfo) (git.Tag, error)
-}
-
-func (m GitRepositoryMock) Zipball(info git.RepoInfo, version string) (io.ReadCloser, error) {
-	return m.zipball(info, version)
-}
-
-func (m GitRepositoryMock) Tags(info git.RepoInfo) (git.Tags, error) {
-	return m.tags(info)
-}
-
-func (m GitRepositoryMock) LatestTag(info git.RepoInfo) (git.Tag, error) {
-	return m.latestTag(info)
 }

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -194,8 +194,7 @@ func TestTree(t *testing.T) {
 }
 
 func cleanRitHome() {
-	fileManager := stream.NewFileManager()
-	_ = fileManager.Remove(ritHome)
+	_ = os.RemoveAll(ritHome)
 }
 
 func isSameTree(tree, expected map[string]formula.Tree) bool {
@@ -212,6 +211,10 @@ func isSameTree(tree, expected map[string]formula.Tree) bool {
 
 func isSameFormulaTree(formula, expected formula.Tree) bool {
 	for i, v := range formula.Commands {
+		commandsExists := expected.Commands[i] != api.Command{}
+		if !commandsExists {
+			return false
+		}
 		if !isSameCommand(v, expected.Commands[i]) {
 			return false
 		}

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -195,10 +195,8 @@ func TestTree(t *testing.T) {
 				},
 				file: FileReadExisterMock{
 					exists: func(path string) bool {
-						if strings.Contains(path, "/someRepo/tree.json") {
-							return true
-						}
-						return false
+						isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
+						return isSomeRepo
 					},
 					read: func(path string) ([]byte, error) {
 						if strings.Contains(path, "/someRepo/tree.json") {
@@ -286,10 +284,8 @@ func TestTree(t *testing.T) {
 				},
 				file: FileReadExisterMock{
 					exists: func(path string) bool {
-						if strings.Contains(path, "/someRepo/tree.json") {
-							return true
-						}
-						return false
+						isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
+						return isSomeRepo
 					},
 					read: func(path string) ([]byte, error) {
 						if strings.Contains(path, "/someRepo/tree.json") {

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -19,6 +19,7 @@ package tree
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,8 +32,9 @@ import (
 )
 
 var (
-	tmpDir  = os.TempDir()
-	ritHome = filepath.Join(tmpDir, ".rit-tree")
+	tmpDir           = os.TempDir()
+	ritHome          = filepath.Join(tmpDir, ".rit-tree")
+	pathTreeSomeRepo = fmt.Sprintf(treeRepoCmdPattern, ritHome, "someRepo")
 
 	coreCmds = []api.Command{
 		{Parent: "root", Usage: "add"},
@@ -54,6 +56,9 @@ func TestMergedTree(t *testing.T) {
 		{Parent: "root", Usage: "jedi-list"},
 		{Parent: "root_jedi-list", Usage: "add"},
 	}}
+
+	pathTreeLocalRepo := fmt.Sprintf(treeLocalCmdPattern, ritHome)
+	pathTreeOtherRepo := fmt.Sprintf(treeRepoCmdPattern, ritHome, "otherRepo")
 
 	expectedTreeComplete := formula.Tree{
 		Commands: api.Commands{
@@ -108,9 +113,9 @@ func TestMergedTree(t *testing.T) {
 
 	fileManager := FileReadExisterMock{
 		exists: func(path string) bool {
-			isLocalRepo := strings.Contains(path, "/local/tree.json")
-			isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
-			isOtherRepo := strings.Contains(path, "/otherRepo/tree.json")
+			isLocalRepo := strings.Contains(path, pathTreeLocalRepo)
+			isSomeRepo := strings.Contains(path, pathTreeSomeRepo)
+			isOtherRepo := strings.Contains(path, pathTreeOtherRepo)
 
 			if isLocalRepo || isSomeRepo || isOtherRepo {
 				return true
@@ -118,9 +123,9 @@ func TestMergedTree(t *testing.T) {
 			return false
 		},
 		read: func(path string) ([]byte, error) {
-			isLocalRepo := strings.Contains(path, "/local/tree.json")
-			isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
-			isOtherRepo := strings.Contains(path, "/otherRepo/tree.json")
+			isLocalRepo := strings.Contains(path, pathTreeLocalRepo)
+			isSomeRepo := strings.Contains(path, pathTreeSomeRepo)
+			isOtherRepo := strings.Contains(path, pathTreeOtherRepo)
 
 			if isLocalRepo {
 				return []byte(getStringOfTree(localTree)), nil
@@ -195,11 +200,11 @@ func TestTree(t *testing.T) {
 				},
 				file: FileReadExisterMock{
 					exists: func(path string) bool {
-						isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
+						isSomeRepo := strings.Contains(path, pathTreeSomeRepo)
 						return isSomeRepo
 					},
 					read: func(path string) ([]byte, error) {
-						if strings.Contains(path, "/someRepo/tree.json") {
+						if strings.Contains(path, pathTreeSomeRepo) {
 							return []byte(getStringOfTree(someRepoTree)), nil
 						}
 						return []byte("some data"), nil
@@ -284,11 +289,11 @@ func TestTree(t *testing.T) {
 				},
 				file: FileReadExisterMock{
 					exists: func(path string) bool {
-						isSomeRepo := strings.Contains(path, "/someRepo/tree.json")
+						isSomeRepo := strings.Contains(path, pathTreeSomeRepo)
 						return isSomeRepo
 					},
 					read: func(path string) ([]byte, error) {
-						if strings.Contains(path, "/someRepo/tree.json") {
+						if strings.Contains(path, pathTreeSomeRepo) {
 							return []byte("some"), errFoo
 						}
 						return []byte("some data"), nil

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -44,16 +44,16 @@ var (
 func TestMergedTree(t *testing.T) {
 	defer cleanRitHome()
 
-	treeLocalFile := filepath.Join(ritHome, "repos", "local")
-	treeSomeRepoFile := filepath.Join(ritHome, "repos", "someRepo")
+	treeLocalDir := filepath.Join(ritHome, "repos", "local")
+	treeSomeRepoDir := filepath.Join(ritHome, "repos", "someRepo")
 
 	createDir(ritHome)
-	createDir(treeLocalFile)
-	createDir(treeSomeRepoFile)
+	createDir(treeLocalDir)
+	createDir(treeSomeRepoDir)
 
 	localTree := formula.Tree{Commands: []api.Command{
-		{Parent: "root", Usage: "jedis-list"},
-		{Parent: "root_jedis-list", Usage: "add"},
+		{Parent: "root", Usage: "jedi-list"},
+		{Parent: "root_jedi-list", Usage: "add"},
 	}}
 
 	someRepoTree := formula.Tree{Commands: []api.Command{
@@ -61,8 +61,8 @@ func TestMergedTree(t *testing.T) {
 		{Parent: "root_pokemon-list", Usage: "add"},
 	}}
 
-	addTreeLocal(treeLocalFile, localTree)
-	addTreeLocal(treeSomeRepoFile, someRepoTree)
+	addTreeLocal(treeLocalDir, localTree)
+	addTreeLocal(treeSomeRepoDir, someRepoTree)
 
 	expectedTreeComplete := formula.Tree{
 		Commands: api.Commands{
@@ -71,11 +71,11 @@ func TestMergedTree(t *testing.T) {
 			coreCmds[2],
 			{
 				Parent: "root",
-				Usage:  "jedis-list",
+				Usage:  "jedi-list",
 				Repo:   "local",
 			},
 			{
-				Parent: "root_jedis-list",
+				Parent: "root_jedi-list",
 				Usage:  "add",
 				Repo:   "local",
 			},


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**

In this PR we exchange the use of `io/ioutil` and `/fileutil` to `FileReadExister`  in all functions of `default_tree.go` file.

**- How to verify it**

Check the file `default tree.go` to see the difference and in the tests of the related file check the use of interface.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Default tree refactoring to use file manager of package stream