### PR TITLE
refactor: remove emojis

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,7 +125,7 @@ func buildCommands() *cobra.Command {
 	ctxFindRemover := rcontext.NewFindRemover(ritchieHomeDir, ctxFinder, ctxRemover)
 	credSetter := credential.NewSetter(ritchieHomeDir, ctxFinder)
 	credFinder := credential.NewFinder(ritchieHomeDir, ctxFinder, fileManager)
-	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds)
+	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds, fileManager)
 	credSettings := credential.NewSettings(fileManager, dirManager, userHomeDir)
 	autocompleteGen := autocomplete.NewGenerator(treeManager)
 	credResolver := envcredential.NewResolver(credFinder, credSetter, inputPassword)

--- a/pkg/autocomplete/generator_test.go
+++ b/pkg/autocomplete/generator_test.go
@@ -32,6 +32,16 @@ func (repoListerMock) List() (formula.Repos, error) {
 	return formula.Repos{}, nil
 }
 
+type FileReadExisterMock struct{}
+
+func (m FileReadExisterMock) Read(path string) ([]byte, error) {
+	return []byte("some data"), nil
+}
+
+func (m FileReadExisterMock) Exists(path string) bool {
+	return false
+}
+
 func TestGenerate(t *testing.T) {
 	type in struct {
 		shell ShellName
@@ -41,7 +51,7 @@ func TestGenerate(t *testing.T) {
 		err error
 	}
 
-	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.Commands{})
+	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.Commands{}, FileReadExisterMock{})
 	autocomplete := NewGenerator(treeMan)
 
 	tests := []struct {

--- a/pkg/cmd/build_formula.go
+++ b/pkg/cmd/build_formula.go
@@ -152,7 +152,7 @@ func (b buildFormulaCmd) build(workspacePath, formulaPath string) {
 		return
 	}
 
-	success := prompt.Green("✔ Build completed!\n")
+	success := prompt.Green("Build completed!\n")
 	s.Success(success)
 
 	const MessageWatch = `Are you testing your formula? You can use the flag --watch to avoid

--- a/pkg/cmd/create_formula.go
+++ b/pkg/cmd/create_formula.go
@@ -186,7 +186,7 @@ func (c createFormulaCmd) create(cf formula.Create, workspacePath, formulaPath s
 }
 
 func createSuccess(s *spinner.Spinner, lang string) {
-	msg := fmt.Sprintf("✔ %s formula successfully created!", lang)
+	msg := fmt.Sprintf("%s formula successfully created!", lang)
 	success := prompt.Green(msg)
 	s.Success(success)
 }

--- a/pkg/cmd/delete_formula.go
+++ b/pkg/cmd/delete_formula.go
@@ -160,7 +160,7 @@ func (d deleteFormulaCmd) runPrompt() CommandRunnerFunc {
 			}
 		}
 
-		prompt.Success("✔ Formula successfully deleted!")
+		prompt.Success("Formula successfully deleted!")
 
 		return nil
 	}

--- a/pkg/cmd/delete_workspace.go
+++ b/pkg/cmd/delete_workspace.go
@@ -112,7 +112,7 @@ func (d deleteWorkspaceCmd) runPrompt() CommandRunnerFunc {
 			}
 		}
 
-		prompt.Success("✔ Workspace successfully deleted!")
+		prompt.Success("Workspace successfully deleted!")
 
 		return nil
 	}

--- a/pkg/cmd/set_credential.go
+++ b/pkg/cmd/set_credential.go
@@ -85,7 +85,7 @@ func (s setCredentialCmd) runPrompt() CommandRunnerFunc {
 		if err := s.Set(cred); err != nil {
 			return err
 		}
-		prompt.Success(fmt.Sprintf("✔ %s credential saved!", strings.Title(cred.Service)))
+		prompt.Success(fmt.Sprintf("%s credential saved!", strings.Title(cred.Service)))
 		prompt.Info("Check your credentials using rit list credential")
 
 		return nil

--- a/pkg/formula/creator/creator_test.go
+++ b/pkg/formula/creator/creator_test.go
@@ -52,7 +52,7 @@ func TestCreator(t *testing.T) {
 	_ = dirManager.Remove(resultDir)
 	_ = dirManager.Create(resultDir)
 
-	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.CoreCmds)
+	treeMan := tree.NewTreeManager("../../testdata", repoListerMock{}, api.CoreCmds, FileReadExisterMock{})
 
 	tplM := template.NewManager("../../../testdata", dirManager)
 
@@ -197,4 +197,14 @@ type repoListerMock struct{}
 
 func (repoListerMock) List() (formula.Repos, error) {
 	return formula.Repos{}, nil
+}
+
+type FileReadExisterMock struct{}
+
+func (m FileReadExisterMock) Read(path string) ([]byte, error) {
+	return []byte("some data"), nil
+}
+
+func (m FileReadExisterMock) Exists(path string) bool {
+	return false
 }

--- a/pkg/formula/watcher/watcher.go
+++ b/pkg/formula/watcher/watcher.go
@@ -100,7 +100,7 @@ func (w WatchManager) build(workspacePath, formulaPath string) {
 		return
 	}
 
-	success := prompt.Green("✔ Build completed!")
+	success := prompt.Green("Build completed!")
 	s.Success(success)
 	prompt.Info("Now you can run your formula with Ritchie!")
 }


### PR DESCRIPTION
**- What I did**

- Remove emojis from sentences because `cmd` and `powershell` are not displayed correctly

![cmd](https://media.giphy.com/media/N4445D1wP07TTBI25z/giphy.gif)

**- How to verify it**

- Run `rit build formula`

**- Description for the changelog**
- Remove emojis from sentences because `cmd` and `powershell` are not displayed correctly