### PR TITLE
Set tutorial output more informative

### DIFF
--- a/functional/core/core_feature.json
+++ b/functional/core/core_feature.json
@@ -352,7 +352,7 @@
                 "action": "sendkey"
             }
         ],
-        "result": "Set tutorial successful!"
+        "result": "Tutorial disabled!"
     },
     {
         "entry": "Upgrade",

--- a/pkg/cmd/tutorial.go
+++ b/pkg/cmd/tutorial.go
@@ -68,7 +68,7 @@ func (o tutorialCmd) runStdin() CommandRunnerFunc {
 			return err
 		}
 
-		prompt.Success("Set tutorial " + obj.Tutorial + " successful!")
+		prompt.Success("Tutorial " + obj.Tutorial + "!")
 
 		return nil
 	}
@@ -96,7 +96,7 @@ func (o tutorialCmd) runPrompt() CommandRunnerFunc {
 		if err != nil {
 			return err
 		}
-		prompt.Success("Set tutorial " + response + " successful!")
+		prompt.Success("Tutorial " + response + "!")
 		return nil
 	}
 }

--- a/pkg/cmd/tutorial.go
+++ b/pkg/cmd/tutorial.go
@@ -68,7 +68,7 @@ func (o tutorialCmd) runStdin() CommandRunnerFunc {
 			return err
 		}
 
-		prompt.Success("Set tutorial successful!")
+		prompt.Success("Set tutorial " + obj.Tutorial + " successful!")
 
 		return nil
 	}
@@ -96,7 +96,7 @@ func (o tutorialCmd) runPrompt() CommandRunnerFunc {
 		if err != nil {
 			return err
 		}
-		prompt.Success("Set tutorial successful!")
+		prompt.Success("Set tutorial " + response + " successful!")
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Harirai <harim1709@gmail.com>
Fixes #525
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
Added user response to `rit tutorial` for more clarity, previously output was "Set tutorial successful" irrespective of user response.
Now it shows output corresponding to the input.
Like: "Set tutorial enabled successful".
**- How to verify it**
By setting tutorial.
**- Description for the changelog**
Set tutorial output more informative.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
