### PR TITLE
Remove preinst.sh script

### DIFF
--- a/packaging/debian/deb.json
+++ b/packaging/debian/deb.json
@@ -11,6 +11,5 @@
             "fperm": "0755"
         }
     ],
-    "preinst-file": "packaging/scripts/preinst.sh",
     "postinst-file": "packaging/scripts/postinst.sh"
 }

--- a/packaging/rpm/rpm.json
+++ b/packaging/rpm/rpm.json
@@ -12,6 +12,5 @@
             "type": ""
         }
     ],
-    "preinst": "packaging/scripts/preinst.sh",
     "postinst": "packaging/scripts/postinst.sh"
 }

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -1,11 +1,6 @@
 #!/bin/sh -xe
 
 idempotent_config() {
-  if [ -d ${HOME}"/.rit" ]; then
-	  echo "~/.rit directory already exists, moving on"
-  else
-	  mkdir ${HOME}"/.rit"
-  fi
   if [ -n "$SHELL_TYPE" ]; then
 
     if [ -f ${HOME}"/."${SHELL_TYPE}"rc" ]; then

--- a/packaging/scripts/preinst.sh
+++ b/packaging/scripts/preinst.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -xe
-
-rm -rf ~/.rit


### PR DESCRIPTION
**- What I did**
I removed preinst.sh script for packing in Debian and rpm to not removing the **.rit** directory.

**- How to verify it**
Install the stable version of Ritchie-cli on your machine, initialize it and add a credential, after that install the QA version.

The QA version cannot remove the .rit folder!

Download the QA version:
- [Debian](https://qa-repo.ritchiecli.io/2.0.0-qa/installer/ritchiecli.deb)
- [RPM](https://qa-repo.ritchiecli.io/2.0.0-qa/installer/ritchiecli.rpm)

**- Description for the changelog**
Removed preinst.sh
