### PR TITLE
refactor: add timeout to the functional testing job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
           name: Running Functional tests for CLI
           command: |
             make functional-test
+          no_output_timeout: 10m
 
   windows_functional_test:
     executor: windows-executor


### PR DESCRIPTION
**- What I did**

- Add timeout to the functional testing job to prevent it from running for hours, optimizing build time

**- How to verify it**

- Track job execution

**- Description for the changelog**

- Add timeout to the functional testing job to prevent it from running for hours, optimizing build time