### PR TITLE
[Fix] - Searching only for run.sh on docker pre run

### DIFF
--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -148,6 +148,10 @@ func (d *Definition) TmpWorkDirPath(home string) string {
 	return filepath.Join(home, TmpDir, u)
 }
 
+func (d *Definition) UnixBinFilePath(fPath string) string {
+	return filepath.Join(fPath, BinDir, BinUnix)
+}
+
 // BinFilePath builds the bin file path from formula path
 func (d *Definition) BinFilePath(fPath string) string {
 	return filepath.Join(fPath, BinDir, d.BinName())

--- a/pkg/formula/runner/docker/pre_run.go
+++ b/pkg/formula/runner/docker/pre_run.go
@@ -79,7 +79,7 @@ func (pr PreRunManager) PreRun(def formula.Definition) (formula.Setup, error) {
 		return formula.Setup{}, err
 	}
 
-	binFilePath := def.BinFilePath(formulaPath)
+	binFilePath := def.UnixBinFilePath(formulaPath)
 	if !pr.file.Exists(binFilePath) {
 		s := spinner.StartNew("Building formula...")
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
Signed-off-by: JoaoDanielRufino <joaodaniel0405@gmail.com>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
When building a formula with docker on windows, the CLI only checks if there is a run.bat file, but on docker it is necessary to check if there is a run.sh file to build the formula.

**- How to verify it**
Build a formula locally on windows and then run the formula with docker.

**- Description for the changelog**
Check if there is run.sh file when building formula with docker.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
