### PR TITLE
Add env docker_execution

### DIFF
--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -34,6 +34,7 @@ const (
 	PwdEnv        = "CURRENT_PWD"
 	CtxEnv        = "CONTEXT"
 	VerboseEnv    = "VERBOSE_MODE"
+	DockerExecutionEnv    = "DOCKER_EXECUTION"
 	BinUnix       = "run.sh"
 	BinWindows    = "run.bat"
 	BinDir        = "bin"

--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -28,17 +28,17 @@ import (
 )
 
 const (
-	ReposDir      = "repos"
-	TmpDir        = "tmp"
-	DefaultConfig = "config.json"
-	PwdEnv        = "CURRENT_PWD"
-	CtxEnv        = "CONTEXT"
-	VerboseEnv    = "VERBOSE_MODE"
-	DockerExecutionEnv    = "DOCKER_EXECUTION"
-	BinUnix       = "run.sh"
-	BinWindows    = "run.bat"
-	BinDir        = "bin"
-	EnvPattern    = "%s=%s"
+	ReposDir           = "repos"
+	TmpDir             = "tmp"
+	DefaultConfig      = "config.json"
+	PwdEnv             = "CURRENT_PWD"
+	CtxEnv             = "CONTEXT"
+	VerboseEnv         = "VERBOSE_MODE"
+	DockerExecutionEnv = "DOCKER_EXECUTION"
+	BinUnix            = "run.sh"
+	BinWindows         = "run.bat"
+	BinDir             = "bin"
+	EnvPattern         = "%s=%s"
 )
 
 type (

--- a/pkg/formula/runner/docker/runner.go
+++ b/pkg/formula/runner/docker/runner.go
@@ -122,10 +122,11 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 		return err
 	}
 
+	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "true")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)
 	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, ctx.Current)
 	verboseEnv := fmt.Sprintf(formula.EnvPattern, formula.VerboseEnv, strconv.FormatBool(verbose))
-	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv)
+	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv)
 
 	for _, e := range cmd.Env { // Create a file named .env and add the environment variable inName=inValue
 		if !ru.file.Exists(envFile) {

--- a/pkg/formula/runner/local/runner.go
+++ b/pkg/formula/runner/local/runner.go
@@ -103,10 +103,11 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 	}
 
 	cmd.Env = os.Environ()
+	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "false")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)
 	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, ctx.Current)
 	verboseEnv := fmt.Sprintf(formula.EnvPattern, formula.VerboseEnv, strconv.FormatBool(verbose))
-	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv)
+	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Fabiano Chiareto Fernandes <fabiano.fernandes@zup.com.br>

**- What I did**

Added docker_execution env by default for all docker runs. 
So that it is possible to identify the type of execution within the formula and create different behaviors.

**- How to verify it**
Run a formula with the --docker flag and inside the container will be created env DOCKER_EXECUTION = true

**- Description for the changelog**
Added docker_execution env by default for all docker runs. 
