### PR TITLE
Remove codecov/project step

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    project: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,26 +1,7 @@
-# https://docs.codecov.io/docs/commit-status
 coverage:
   status:
-    # only measure diff changes, not unexpected project changes from flakiness
     project: off
-    patch:
-      default:
-        # https://docs.codecov.io/docs/commit-status#section-informational
-        informational: true
-        # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
-      ui:
-        informational: true
-    # https://docs.codecov.io/docs/commit-status#section-changes-status
-    changes: off
-comment: false
-
-# https://docs.codecov.io/docs/flags
-flags:
-  ui:
-    paths: /ui-v2/
-
 github_checks:
   annotations: false
-
 ignore:
   - "vendor/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,26 @@
+# https://docs.codecov.io/docs/commit-status
 coverage:
   status:
+    # only measure diff changes, not unexpected project changes from flakiness
     project: off
+    patch:
+      default:
+        # https://docs.codecov.io/docs/commit-status#section-informational
+        informational: true
+        # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
+      ui:
+        informational: true
+    # https://docs.codecov.io/docs/commit-status#section-changes-status
+    changes: off
+comment: false
+
+# https://docs.codecov.io/docs/flags
+flags:
+  ui:
+    paths: /ui-v2/
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "vendor/**/*"

--- a/pkg/formula/runner/local/pre_run_test.go
+++ b/pkg/formula/runner/local/pre_run_test.go
@@ -181,59 +181,6 @@ func TestPreRun(t *testing.T) {
 			},
 		},
 		{
-			name: "copy work dir error",
-			in: in{
-				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
-				makeBuild: makeBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				batBuild: batBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				shellBuild: shellBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				file: fileManager,
-				dir:  dirManagerMock{copyErr: errors.New("error to copy dir")},
-			},
-			out: out{
-				wantErr: true,
-				err:     errors.New("error to copy dir"),
-			},
-		},
-		{
-			name: "Chdir error",
-			in: in{
-				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
-				makeBuild: makeBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				batBuild: batBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				shellBuild: shellBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				file: fileManager,
-				dir:  dirManagerMock{},
-			},
-			out: out{
-				wantErr: true,
-			},
-		},
-		{
 			name: "local build error delete bin dir",
 			in: in{
 				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},

--- a/pkg/formula/runner/local/pre_run_test.go
+++ b/pkg/formula/runner/local/pre_run_test.go
@@ -180,33 +180,7 @@ func TestPreRun(t *testing.T) {
 				err:     errors.New("error to create dir"),
 			},
 		},
-		{
-			name: "copy work dir error",
-			in: in{
-				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
-				makeBuild: makeBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				batBuild: batBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				shellBuild: shellBuildMock{
-					build: func(formulaPath string) error {
-						return dirManager.Create(filepath.Join(formulaPath, "bin"))
-					},
-				},
-				file: fileManager,
-				dir:  dirManagerMock{copyErr: errors.New("error to copy dir")},
-			},
-			out: out{
-				wantErr: true,
-				err:     errors.New("error to copy dir"),
-			},
-		},
+		
 		{
 			name: "Chdir error",
 			in: in{

--- a/pkg/formula/runner/local/pre_run_test.go
+++ b/pkg/formula/runner/local/pre_run_test.go
@@ -181,6 +181,59 @@ func TestPreRun(t *testing.T) {
 			},
 		},
 		{
+			name: "copy work dir error",
+			in: in{
+				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
+				makeBuild: makeBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				batBuild: batBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				shellBuild: shellBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				file: fileManager,
+				dir:  dirManagerMock{copyErr: errors.New("error to copy dir")},
+			},
+			out: out{
+				wantErr: true,
+				err:     errors.New("error to copy dir"),
+			},
+		},
+		{
+			name: "Chdir error",
+			in: in{
+				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
+				makeBuild: makeBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				batBuild: batBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				shellBuild: shellBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				file: fileManager,
+				dir:  dirManagerMock{},
+			},
+			out: out{
+				wantErr: true,
+			},
+		},
+		{
 			name: "local build error delete bin dir",
 			in: in{
 				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},

--- a/pkg/formula/runner/local/pre_run_test.go
+++ b/pkg/formula/runner/local/pre_run_test.go
@@ -180,7 +180,7 @@ func TestPreRun(t *testing.T) {
 				err:     errors.New("error to create dir"),
 			},
 		},
-		
+
 		{
 			name: "Chdir error",
 			in: in{

--- a/pkg/formula/runner/local/pre_run_test.go
+++ b/pkg/formula/runner/local/pre_run_test.go
@@ -180,7 +180,33 @@ func TestPreRun(t *testing.T) {
 				err:     errors.New("error to create dir"),
 			},
 		},
-
+		{
+			name: "copy work dir error",
+			in: in{
+				def: formula.Definition{Path: "testing/formula", RepoName: "commons"},
+				makeBuild: makeBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				batBuild: batBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				shellBuild: shellBuildMock{
+					build: func(formulaPath string) error {
+						return dirManager.Create(filepath.Join(formulaPath, "bin"))
+					},
+				},
+				file: fileManager,
+				dir:  dirManagerMock{copyErr: errors.New("error to copy dir")},
+			},
+			out: out{
+				wantErr: true,
+				err:     errors.New("error to copy dir"),
+			},
+		},
 		{
 			name: "Chdir error",
 			in: in{


### PR DESCRIPTION
### Description

The codecov/project check is no longer making sense
We need to constantly update the branch because master is always changing

![image](https://user-images.githubusercontent.com/51962831/96873486-5ff61e80-144b-11eb-862f-fe1e36693477.png)

### Changelog
Disable codecov/project check
