### PR TITLE
added context printing

### DIFF
--- a/pkg/formula/runner/local/pre_run.go
+++ b/pkg/formula/runner/local/pre_run.go
@@ -146,6 +146,7 @@ func (pr PreRunManager) loadConfig(formulaPath string, def formula.Definition) (
 	if err != nil {
 		return formula.Config{}, err
 	}
+	
 	var formulaConfig formula.Config
 	if err := json.Unmarshal(configFile, &formulaConfig); err != nil {
 		return formula.Config{}, err

--- a/pkg/formula/runner/local/pre_run.go
+++ b/pkg/formula/runner/local/pre_run.go
@@ -146,7 +146,6 @@ func (pr PreRunManager) loadConfig(formulaPath string, def formula.Definition) (
 	if err != nil {
 		return formula.Config{}, err
 	}
-	
 	var formulaConfig formula.Config
 	if err := json.Unmarshal(configFile, &formulaConfig); err != nil {
 		return formula.Config{}, err

--- a/pkg/formula/runner/local/pre_run.go
+++ b/pkg/formula/runner/local/pre_run.go
@@ -146,7 +146,6 @@ func (pr PreRunManager) loadConfig(formulaPath string, def formula.Definition) (
 	if err != nil {
 		return formula.Config{}, err
 	}
-
 	var formulaConfig formula.Config
 	if err := json.Unmarshal(configFile, &formulaConfig); err != nil {
 		return formula.Config{}, err

--- a/pkg/formula/runner/local/runner.go
+++ b/pkg/formula/runner/local/runner.go
@@ -102,6 +102,13 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 		return err
 	}
 
+	ctxToPrint := ctx.Current
+	if ctxToPrint == "" {
+		ctxToPrint = "default"
+	}
+	prompt.Info(
+		fmt.Sprintf("Formula running  on context: %s\n", prompt.Cyan(ctxToPrint)),
+	)
 	cmd.Env = os.Environ()
 	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "false")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)

--- a/pkg/formula/runner/local/runner.go
+++ b/pkg/formula/runner/local/runner.go
@@ -102,13 +102,12 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 		return err
 	}
 
-	ctxToPrint := ctx.Current
-	if ctxToPrint == "" {
-		ctxToPrint = "default"
+	if ctx.Current != "" {
+		prompt.Info(
+			fmt.Sprintf("Formula running on context: %s\n", prompt.Cyan(ctx.Current)),
+		)
 	}
-	prompt.Info(
-		fmt.Sprintf("Formula running  on context: %s\n", prompt.Cyan(ctxToPrint)),
-	)
+
 	cmd.Env = os.Environ()
 	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "false")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)

--- a/pkg/formula/runner/local/runner_test.go
+++ b/pkg/formula/runner/local/runner_test.go
@@ -144,6 +144,22 @@ func TestRun(t *testing.T) {
 				err: errors.New("context not found"),
 			},
 		},
+		{
+			name: "success with a non default context",
+			in: in{
+				def:         formula.Definition{Path: "testing/formula", RepoName: "commons"},
+				preRun:      preRunner,
+				postRun:     postRunner,
+				inputRun:    inputRunner,
+				fileManager: fileManagerMock{exist: true, aErr: errors.New("error to append env file")},
+				context:     ctxFinderMock{ctx: rcontext.ContextHolder{
+					Current: "prod",
+				}},
+			},
+			out: out{
+				err: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

Most of users want to be sure about which context your formula will be ran, a common behaviour about this is to use ```rit set context``` just to see the context.

Printing the context after the start of every formula can help on this 

![image](https://user-images.githubusercontent.com/51962831/97003764-54215f80-1512-11eb-9451-92e14746444c.png)


### How to verify it
Run some formula

### Changelog
added context printing
