### PR TITLE
added warning on same env name

### DIFF
--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -178,7 +179,16 @@ func (in InputManager) fromPrompt(cmd *exec.Cmd, setup formula.Setup) error {
 // addEnv Add environment variable to run formulas.
 // add the variable inName=inValue to cmd.Env
 func addEnv(cmd *exec.Cmd, inName, inValue string) {
-	e := fmt.Sprintf(formula.EnvPattern, strings.ToUpper(inName), inValue)
+	envKey := strings.ToUpper(inName)
+	fmt.Println(envKey)
+	if _, exist := os.LookupEnv(envKey); exist {
+		warnMsg := fmt.Sprintf(
+			"The input param %s has the same name of a machine variable." +
+				" It will probably result on unexpect behavior", envKey)
+		prompt.Warning(warnMsg)
+	}
+
+	e := fmt.Sprintf(formula.EnvPattern, envKey, inValue)
 	cmd.Env = append(cmd.Env, e)
 }
 

--- a/pkg/formula/runner/inputs.go
+++ b/pkg/formula/runner/inputs.go
@@ -180,7 +180,6 @@ func (in InputManager) fromPrompt(cmd *exec.Cmd, setup formula.Setup) error {
 // add the variable inName=inValue to cmd.Env
 func addEnv(cmd *exec.Cmd, inName, inValue string) {
 	envKey := strings.ToUpper(inName)
-	fmt.Println(envKey)
 	if _, exist := os.LookupEnv(envKey); exist {
 		warnMsg := fmt.Sprintf(
 			"The input param %s has the same name of a machine variable." +

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -101,7 +101,7 @@ func TestInputManager_Inputs(t *testing.T) {
 	var inputs []formula.Input
 	_ = json.Unmarshal([]byte(inputJson), &inputs)
 	_ = os.Setenv("SAMPLE_TEXT", "someValue")
-	
+
 	setup := formula.Setup{
 		Config: formula.Config{
 			Inputs: inputs,

--- a/pkg/formula/runner/inputs_test.go
+++ b/pkg/formula/runner/inputs_test.go
@@ -100,7 +100,8 @@ func TestInputManager_Inputs(t *testing.T) {
 ]`
 	var inputs []formula.Input
 	_ = json.Unmarshal([]byte(inputJson), &inputs)
-
+	_ = os.Setenv("SAMPLE_TEXT", "someValue")
+	
 	setup := formula.Setup{
 		Config: formula.Config{
 			Inputs: inputs,


### PR DESCRIPTION
### Description

Closes #625 

Using the function ```LookupEnv``` to check. Documentation [here](https://golang.org/pkg/os/#LookupEnv)

Output:
![image](https://user-images.githubusercontent.com/51962831/97171635-89c18500-176c-11eb-956a-3b7b838a90f0.png)

### Changelog
added warning on same env name
