### PR TITLE
Remove repository version check

### DIFF
--- a/pkg/formula/tree/default_tree.go
+++ b/pkg/formula/tree/default_tree.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ZupIT/ritchie-cli/pkg/api"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
-	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
 )
 
@@ -102,21 +101,24 @@ func (d Manager) MergedTree(core bool) formula.Tree {
 		if err != nil {
 			continue
 		}
-		noticeNewVersion := ""
+
+		// TODO: Create a cache for the version of the repositories,
+		//  it is locking the terminal of users with slow internet
+		/*noticeNewVersion := ""
 		if d.isRootCommand {
 			if latestTag := d.getLatestTag(r); latestTag != r.Version.String() && latestTag != "" {
 				noticeNewVersion = prompt.Bold("(new version " + latestTag + ")")
 			}
-		}
+		}*/
 
 		var cc []api.Command
 		for _, c := range treeRepo.Commands {
 			key := c.Parent + "_" + c.Usage
 			if trees[key].Usage == "" {
 				c.Repo = r.Name.String()
-				if noticeNewVersion != "" {
+				/*if noticeNewVersion != "" {
 					c.Repo = noticeNewVersion + " " + c.Repo
-				}
+				}*/
 				trees[key] = c
 				cc = append(cc, c)
 			}

--- a/pkg/formula/tree/default_tree.go
+++ b/pkg/formula/tree/default_tree.go
@@ -129,6 +129,7 @@ func (d Manager) MergedTree(core bool) formula.Tree {
 	return treeMain
 }
 
+//nolint
 func (d Manager) getLatestTag(repo formula.Repo) string {
 	formulaGit := d.repoProviders.Resolve(repo.Provider)
 

--- a/pkg/formula/tree/default_tree_test.go
+++ b/pkg/formula/tree/default_tree_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
 	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/git/github"
-	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 )
 
 var (
@@ -81,12 +80,12 @@ func TestMergedTree(t *testing.T) {
 			{
 				Parent: "root",
 				Usage:  "pokemon-list",
-				Repo:   prompt.Bold("(new version 2.0.0)") + " someRepo",
+				Repo:   "someRepo",
 			},
 			{
 				Parent: "root_pokemon-list",
 				Usage:  "add",
-				Repo:   prompt.Bold("(new version 2.0.0)") + " someRepo",
+				Repo:   "someRepo",
 			},
 		},
 	}
@@ -97,7 +96,7 @@ func TestMergedTree(t *testing.T) {
 		Version:  formula.RepoVersion("1.0.0"),
 		Token:    "token",
 		Url:      "https://github.com/owner/someRepo",
-		Priority: int(5),
+		Priority: 5,
 	}
 	otherRepo := formula.Repo{
 		Provider: formula.RepoProvider("Github"),
@@ -105,7 +104,7 @@ func TestMergedTree(t *testing.T) {
 		Version:  formula.RepoVersion("1.0.0"),
 		Token:    "token",
 		Url:      "https://github.com/owner/otherRepo",
-		Priority: int(5),
+		Priority: 5,
 	}
 
 	repoLister := repositoryListerCustomMock{


### PR DESCRIPTION
### Description

When carrying out the construction of the command tree, we make requests to check the latest version of each formula repository, but this has been showing crashes in the user terminal with slow internet. We commented on this part of the code to do a better analysis and create a more robust solution to this problem.

##### Before:
![image](https://user-images.githubusercontent.com/17505818/98389824-57990880-2033-11eb-9602-c263ab4f6d7e.png)


##### After:
![image](https://user-images.githubusercontent.com/17505818/98389710-31736880-2033-11eb-976e-52b9037629b6.png)


### How to verify it

Now you cannot see the new repositories version when executing the **rit** command

### Changelog
Removed repository version check