### PR TITLE
Create new rit show env command

### DIFF
--- a/functional/core/core_feature.json
+++ b/functional/core/core_feature.json
@@ -1,14 +1,14 @@
 [
     {
-        "entry": "Show context",
+        "entry": "Show env",
         "steps": [
             {
                 "key": "",
-                "value": "show context",
+                "value": "show env",
                 "action": "main"
             }
         ],
-        "result": "Current context:"
+        "result": "Current env:"
     },
     {
         "entry": "Set env",
@@ -303,7 +303,7 @@
                 "action": "main"
             }
         ],
-        "result": "Show current context and formula-runnner default"
+        "result": "Show current env and formula-runner default"
     },
     {
         "entry": "Create",

--- a/functional/init/init_feature.json
+++ b/functional/init/init_feature.json
@@ -1,14 +1,14 @@
 [
     {
-        "entry":"Show context",
+        "entry":"Show env",
         "steps":[
             {
                 "key":"",
-                "value":"show context",
+                "value":"show env",
                 "action":"main"
             }
         ],
-        "result":"Current context: default"
+        "result":"Current env: default"
     },
     {
         "entry":"Set env",

--- a/functional/init/init_integration_test.go
+++ b/functional/init/init_integration_test.go
@@ -45,7 +45,7 @@ var _ = Describe("RitSingleInit", func() {
 			Expect(out).To(ContainSubstring(scenario.Result))
 		},
 
-		Entry("Show context", scenariosCore[0]),
+		Entry("Show env", scenariosCore[0]),
 		Entry("Set env", scenariosCore[1]),
 		Entry("Delete context", scenariosCore[2]),
 		Entry("List repo", scenariosCore[3]),

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,7 +54,7 @@ var (
 		{Parent: "root_set", Usage: "repo-priority"},
 		{Parent: "root_set", Usage: "formula-runner"},
 		{Parent: "root", Usage: "show"},
-		{Parent: "root_show", Usage: "context"},
+		{Parent: "root_show", Usage: "env"},
 		{Parent: "root_show", Usage: "formula-runner"},
 		{Parent: "root", Usage: "create"},
 		{Parent: "root_create", Usage: "formula"},

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -211,16 +211,16 @@ func (ctxSetterMock) Set(ctx string) (env.Holder, error) {
 	return env.Holder{}, nil
 }
 
-type ctxFinderMock struct{}
+type envFinderMock struct{}
 
-func (ctxFinderMock) Find() (env.Holder, error) {
+func (envFinderMock) Find() (env.Holder, error) {
 	return env.Holder{}, nil
 }
 
 type ctxFindRemoverMock struct{}
 
 func (ctxFindRemoverMock) Find() (env.Holder, error) {
-	f := ctxFinderMock{}
+	f := envFinderMock{}
 	return f.Find()
 }
 
@@ -231,7 +231,7 @@ func (ctxFindRemoverMock) Remove(ctx string) (env.Holder, error) {
 type envFindSetterMock struct{}
 
 func (envFindSetterMock) Find() (env.Holder, error) {
-	f := ctxFinderMock{}
+	f := envFinderMock{}
 	return f.Find()
 }
 

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -16,15 +16,31 @@
 
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ZupIT/ritchie-cli/pkg/prompt"
+)
 
 func NewShowCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:       "show SUB_COMMAND",
-		Short:     "Show context and formula-runnner default",
-		Long:      "Show current context and formula-runnner default",
-		Example:   "rit show context",
-		ValidArgs: []string{"context", "formula-runner"},
+		Short:     "Show env and formula-runner default",
+		Long:      "Show current env and formula-runner default",
+		Example:   "rit show env",
+		ValidArgs: []string{"env", "formula-runner"},
 		Args:      cobra.OnlyValidArgs,
 	}
+
+	deprecatedMsg := fmt.Sprintf(
+		`you can now use the "%v" command for the same purpose as the "%v" command.`,
+		prompt.Bold("rit show env"),
+		prompt.Bold("rit show context"),
+	)
+
+	DeprecateCmd(cmd, "context", deprecatedMsg)
+
+	return cmd
 }

--- a/pkg/cmd/show_env.go
+++ b/pkg/cmd/show_env.go
@@ -26,35 +26,35 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 )
 
-type showContextCmd struct {
-	env.Finder
+type showEnvCmd struct {
+	env env.Finder
 }
 
-func NewShowContextCmd(f env.Finder) *cobra.Command {
-	s := showContextCmd{f}
+func NewShowEnvCmd(f env.Finder) *cobra.Command {
+	s := showEnvCmd{f}
 
 	return &cobra.Command{
-		Use:       "context",
-		Short:     "Show current context",
-		Example:   "rit show context",
+		Use:       "env",
+		Short:     "Show current env",
+		Example:   "rit show env",
 		RunE:      s.runFunc(),
 		ValidArgs: []string{""},
 		Args:      cobra.OnlyValidArgs,
 	}
 }
 
-func (s showContextCmd) runFunc() CommandRunnerFunc {
+func (s showEnvCmd) runFunc() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		ctx, err := s.Find()
+		envHolder, err := s.env.Find()
 		if err != nil {
 			return err
 		}
 
-		if ctx.Current == "" {
-			ctx.Current = env.Default
+		if envHolder.Current == "" {
+			envHolder.Current = env.Default
 		}
 
-		prompt.Info(fmt.Sprintf("Current context: %s \n", ctx.Current))
+		fmt.Printf("Current env: %v\n", prompt.Bold(envHolder.Current))
 		return nil
 	}
 }

--- a/pkg/cmd/show_env_test.go
+++ b/pkg/cmd/show_env_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 func TestNewShowContextCmd(t *testing.T) {
-	cmd := NewShowContextCmd(ctxFinderMock{})
+	cmd := NewShowEnvCmd(envFinderMock{})
 	if cmd == nil {
-		t.Errorf("NewShowContextCmd got %v", cmd)
+		t.Errorf("NewShowEnvCmd got %v", cmd)
 
 	}
 

--- a/pkg/commands/builder.go
+++ b/pkg/commands/builder.go
@@ -120,7 +120,7 @@ func Build() *cobra.Command {
 	ctxRemover := env.NewRemover(ritchieHomeDir, ctxFinder, fileManager)
 	ctxFindSetter := env.NewFindSetter(ctxFinder, ctxSetter)
 	ctxFindRemover := env.NewFindRemover(ctxFinder, ctxRemover)
-	credSetter := credential.NewSetter(ritchieHomeDir, ctxFinder)
+	credSetter := credential.NewSetter(ritchieHomeDir, ctxFinder, dirManager, fileManager)
 	credFinder := credential.NewFinder(ritchieHomeDir, ctxFinder, fileManager)
 	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds, fileManager, repoProviders, isRootCommand)
 	treeChecker := tree.NewChecker(treeManager)
@@ -208,7 +208,7 @@ func Build() *cobra.Command {
 
 	deleteCtxCmd := cmd.NewDeleteContextCmd(ctxFindRemover, inputBool, inputList)
 	setCtxCmd := cmd.NewSetEnvCmd(ctxFindSetter, inputText, inputList)
-	showCtxCmd := cmd.NewShowContextCmd(ctxFinder)
+	showCtxCmd := cmd.NewShowEnvCmd(ctxFinder)
 	addRepoCmd := cmd.NewAddRepoCmd(repoAddLister, repoProviders, inputTextValidator, inputPassword, inputURL, inputList, inputBool, inputInt, tutorialFinder, treeChecker)
 	updateRepoCmd := cmd.NewUpdateRepoCmd(http.DefaultClient, repoListUpdater, repoProviders, inputText, inputPassword, inputURL, inputList, inputBool, inputInt)
 	listRepoCmd := cmd.NewListRepoCmd(repoLister, repoProviders, tutorialFinder)

--- a/pkg/credential/finder.go
+++ b/pkg/credential/finder.go
@@ -34,30 +34,30 @@ Try again after use:
 `
 
 type Finder struct {
-	homePath  string
-	ctxFinder env.Finder
-	file      stream.FileReader
+	homePath string
+	env      env.Finder
+	file     stream.FileReader
 }
 
-func NewFinder(homePath string, cf env.Finder, file stream.FileReader) Finder {
+func NewFinder(homePath string, env env.Finder, file stream.FileReader) Finder {
 	return Finder{
-		homePath:  homePath,
-		ctxFinder: cf,
-		file:      file,
+		homePath: homePath,
+		env:      env,
+		file:     file,
 	}
 }
 
 func (f Finder) Find(provider string) (Detail, error) {
-	ctx, err := f.ctxFinder.Find()
+	envHolder, err := f.env.Find()
 
 	if err != nil {
 		return Detail{}, err
 	}
-	if ctx.Current == "" {
-		ctx.Current = env.Default
+	if envHolder.Current == "" {
+		envHolder.Current = env.Default
 	}
 
-	cb, err := f.file.Read(File(f.homePath, ctx.Current, provider))
+	cb, err := f.file.Read(File(f.homePath, envHolder.Current, provider))
 	if err != nil {
 		errMsg := fmt.Sprintf(errNotFoundTemplate, provider)
 		return Detail{Credential: Credential{}}, errors.New(prompt.Red(errMsg))

--- a/pkg/credential/finder_test.go
+++ b/pkg/credential/finder_test.go
@@ -42,14 +42,15 @@ var (
 		},
 	}
 
-	ctxFinder = env.NewFinder("", streamMock)
+	envFinder = env.NewFinder("", streamMock)
 )
 
 func TestFind(t *testing.T) {
 
 	fileManager := stream.NewFileManager()
+	dirManager := stream.NewDirManager(fileManager)
 	tmp := os.TempDir()
-	setter := NewSetter(tmp, ctxFinder)
+	setter := NewSetter(tmp, envFinder, dirManager, fileManager)
 	_ = setter.Set(githubCred)
 
 	type out struct {
@@ -59,7 +60,7 @@ func TestFind(t *testing.T) {
 
 	type in struct {
 		homePath  string
-		ctxFinder env.Finder
+		envFinder env.Finder
 		file      stream.FileReader
 		provider  string
 	}
@@ -73,7 +74,7 @@ func TestFind(t *testing.T) {
 			name: "Run with success",
 			in: in{
 				homePath:  tmp,
-				ctxFinder: ctxFinder,
+				envFinder: envFinder,
 				file:      fileManager,
 				provider:  githubCred.Service,
 			},
@@ -86,7 +87,7 @@ func TestFind(t *testing.T) {
 			name: "Return err when file not exist",
 			in: in{
 				homePath:  tmp,
-				ctxFinder: ctxFinder,
+				envFinder: envFinder,
 				file:      fileManager,
 				provider:  "aws",
 			},
@@ -100,7 +101,7 @@ func TestFind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := tt.out
-			finder := NewFinder(tt.in.homePath, tt.in.ctxFinder, tt.in.file)
+			finder := NewFinder(tt.in.homePath, tt.in.envFinder, tt.in.file)
 			got, err := finder.Find(tt.in.provider)
 			if err != nil && err.Error() != out.err.Error() {
 				t.Errorf("Find(%s) got %v, want %v", tt.name, err, out.err)

--- a/pkg/credential/path.go
+++ b/pkg/credential/path.go
@@ -17,18 +17,15 @@
 package credential
 
 import (
-	"fmt"
+	"path/filepath"
 )
 
-const (
-	pathPattern     = "%s/credentials/%s"
-	credFilePattern = "%s/%s"
-)
+const credentialDir = "credentials"
 
-func Dir(homePath, ctx string) string {
-	return fmt.Sprintf(pathPattern, homePath, ctx)
+func Dir(homePath, env string) string {
+	return filepath.Join(homePath, credentialDir, env)
 }
 
-func File(homePath, ctx, provider string) string {
-	return fmt.Sprintf(credFilePattern, Dir(homePath, ctx), provider)
+func File(homePath, env, provider string) string {
+	return filepath.Join(homePath, credentialDir, env, provider)
 }

--- a/pkg/credential/resolver_test.go
+++ b/pkg/credential/resolver_test.go
@@ -29,9 +29,10 @@ import (
 
 func TestCredentialResolver(t *testing.T) {
 	fileManager := stream.NewFileManager()
+	dirManager := stream.NewDirManager(fileManager)
 	tempDirectory := os.TempDir()
 	contextFinder := env.NewFinder(tempDirectory, fileManager)
-	credentialSetter := NewSetter(tempDirectory, contextFinder)
+	credentialSetter := NewSetter(tempDirectory, contextFinder, dirManager, fileManager)
 	credentialFinder := NewFinder(tempDirectory, contextFinder, fileManager)
 
 	defer os.RemoveAll(File(tempDirectory, "", ""))

--- a/pkg/credential/setter_test.go
+++ b/pkg/credential/setter_test.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
-	"github.com/stretchr/testify/suite"
 )
 
 type SetterTestSuite struct {
@@ -63,7 +64,7 @@ func (suite *SetterTestSuite) fileInfo(path string) (string, error) {
 	return string(b), err
 }
 
-func (suite *SetterTestSuite) TestSetCredentialToDefalt() {
+func (suite *SetterTestSuite) TestSetCredentialToDefault() {
 	for _, t := range []struct {
 		testName string
 		context  env.Holder
@@ -76,7 +77,7 @@ func (suite *SetterTestSuite) TestSetCredentialToDefalt() {
 			filePathExpectedCreated := File(suite.HomePath, suite.envHolderDefault.Current, suite.DetailCredentialInfo.Service)
 
 			contextFinderMock.On("Find").Return(t.context, nil)
-			setter := NewSetter(suite.HomePath, contextFinderMock)
+			setter := NewSetter(suite.HomePath, contextFinderMock, dirManager, fileManager)
 
 			suite.NoFileExists(filePathExpectedCreated)
 

--- a/pkg/formula/runner/local/runner.go
+++ b/pkg/formula/runner/local/runner.go
@@ -41,7 +41,7 @@ type RunManager struct {
 	formula.InputResolver
 	formula.PreRunner
 	file    stream.FileWriteExistAppender
-	ctx     env.Finder
+	env     env.Finder
 	homeDir string
 }
 
@@ -50,7 +50,7 @@ func NewRunner(
 	input formula.InputResolver,
 	preRun formula.PreRunner,
 	file stream.FileWriteExistAppender,
-	ctx env.Finder,
+	env env.Finder,
 	homeDir string,
 ) formula.Runner {
 	return RunManager{
@@ -58,7 +58,7 @@ func NewRunner(
 		InputResolver: input,
 		PreRunner:     preRun,
 		file:          file,
-		ctx:           ctx,
+		env:           env,
 		homeDir:       homeDir,
 	}
 }
@@ -105,21 +105,21 @@ func (ru RunManager) Run(def formula.Definition, inputType api.TermInputType, ve
 }
 
 func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
-	ctx, err := ru.ctx.Find()
+	envHolder, err := ru.env.Find()
 	if err != nil {
 		return err
 	}
 
-	if ctx.Current != "" {
+	if envHolder.Current != "" {
 		prompt.Info(
-			fmt.Sprintf("Formula running on context: %s\n", prompt.Cyan(ctx.Current)),
+			fmt.Sprintf("Formula running on context: %s\n", prompt.Cyan(envHolder.Current)),
 		)
 	}
 
 	cmd.Env = os.Environ()
 	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "false")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)
-	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, ctx.Current)
+	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, envHolder.Current)
 	verboseEnv := fmt.Sprintf(formula.EnvPattern, formula.VerboseEnv, strconv.FormatBool(verbose))
 	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv)
 


### PR DESCRIPTION
### Description
The `rit show context`  command has been deprecated and we will now use the new `rit show env` command which has the same functionality as the old command.

### How to verify it
It's a small part of the #554 issue, a separate pull request was created to facilitate code review

