### PR TITLE
fix: add check for variables with the same name

### DIFF
--- a/pkg/cmd/formula.go
+++ b/pkg/cmd/formula.go
@@ -245,14 +245,13 @@ func (f FormulaCommand) addInputFlags(def formula.Definition, flags *pflag.FlagS
 	_ = json.Unmarshal(file, &config)
 
 	for _, in := range config.Inputs {
+		if flags.Lookup(in.Name) != nil {
+			continue
+		}
+
 		switch in.Type {
 		case input.TextType, input.PassType, input.DynamicType:
-			if len(in.Items) > 0 {
-				tutorial := fmt.Sprintf("%s | accepted items for this field [%s]", in.Tutorial, strings.Join(in.Items, ", "))
-				flags.String(in.Name, in.Default, tutorial)
-			} else {
-				flags.String(in.Name, in.Default, in.Tutorial)
-			}
+			flags.String(in.Name, in.Default, in.Tutorial)
 		case input.BoolType:
 			flags.Bool(in.Name, false, in.Tutorial)
 		}

--- a/pkg/cmd/formula_test.go
+++ b/pkg/cmd/formula_test.go
@@ -124,58 +124,64 @@ func TestFormulaCommand_Add(t *testing.T) {
 
 const inputJson = `{
   "inputs": [
-    {
-      "name": "sample_text",
-      "type": "text",
-      "label": "Type : ",
-      "default": "test"
-    },
-    {
-      "name": "sample_text_2",
-      "type": "text",
-      "label": "Type : ",
-      "required": true
-    },
-    {
-      "name": "sample_list",
-      "type": "text",
-      "default": "in1",
-      "items": [
-        "in_list1",
-        "in_list2",
-        "in_list3",
-        "in_listN"
-      ],
-      "cache": {
-        "active": true,
-        "qty": 3,
-        "newLabel": "Type new value?"
-      },
-      "label": "Pick your : ",
-      "tutorial": "Select an item for this field."
-    },
-    {
-      "name": "sample_bool",
-      "type": "bool",
-      "default": "false",
-      "items": [
-        "false",
-        "true"
-      ],
-      "label": "Pick: ",
-      "tutorial": "Select true or false for this field."
-    },
-    {
-      "name": "sample_password",
-      "type": "password",
-      "label": "Pick: ",
-      "tutorial": "Add a secret password for this field."
-    },
-    {
-      "name": "test_resolver",
-      "type": "CREDENTIAL_TEST"
-    }
-  ]
+		{
+			"name": "sample_text",
+			"type": "text",
+			"label": "Type : ",
+			"default": "test"
+		},
+		{
+			"name": "sample_text",
+			"type": "text",
+			"label": "Type : ",
+			"default": "test"
+		},
+		{
+			"name": "sample_text_2",
+			"type": "text",
+			"label": "Type : ",
+			"required": true
+		},
+		{
+			"name": "sample_list",
+			"type": "text",
+			"default": "in1",
+			"items": [
+				"in_list1",
+				"in_list2",
+				"in_list3",
+				"in_listN"
+			],
+			"cache": {
+				"active": true,
+				"qty": 3,
+				"newLabel": "Type new value?"
+			},
+			"label": "Pick your : ",
+			"tutorial": "Select an item for this field."
+		},
+		{
+			"name": "sample_bool",
+			"type": "bool",
+			"default": "false",
+			"items": [
+				"false",
+				"true"
+			],
+			"label": "Pick: ",
+			"tutorial": "Select true or false for this field."
+		},
+		{
+			"name": "sample_password",
+			"type": "password",
+			"label": "Pick: ",
+			"tutorial": "Add a secret password for this field."
+		},
+		{
+			"name": "test_resolver",
+			"type": "CREDENTIAL_TEST"
+		}
+	]
 }`
 
 type fileReaderMock struct {


### PR DESCRIPTION
### Description

A check has been added in case config.json contains inputs with the same name.

In addition, the default help for flags was removed, because when there are inputs with the same name and they have items, the help was incoherent.

<!-- Gif -->
<p align="center">
  <a rel="noopener" target="_blank"><img width="600px" src="https://media.giphy.com/media/iVmkytI5kGj9XHlSMS/giphy.gif" alt="gif containing the command demonstration"></a>
</p>

![]()

Fix #665 

### How to verify it

1. Make sure you have a form with inputs with the same name
2. Build the formula
3. Run the formula and verify that Ritchie continues to work

### Changelog

Add check for variables with the same name
