### PR TITLE
Convert contexts to envs file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+usage () {
+	echo "./install.sh"
+}
+
+
+idempotent_config() {
+  if [ -n "$SHELL_TYPE" ]; then
+
+    if [ -f ${HOME}"/."${SHELL_TYPE}"rc" ]; then
+
+        sed -i'' -e '/source <(rit completion/d' ${HOME}"/."${SHELL_TYPE}"rc"
+
+        if grep "[[ -r "/usr/local/bin/rit" ]] && rit completion $SHELL_TYPE > ~/.rit_completion" ~/."${SHELL_TYPE}"rc > /dev/null
+        then
+          echo ".${SHELL_TYPE}rc IS ALREADY CONFIGURED TO SUPPORT RITCHIE AUTO COMPLETION"
+        else
+          echo "[[ -r "/usr/local/bin/rit" ]] && rit completion $SHELL_TYPE > ~/.rit_completion" >> ~/."${SHELL_TYPE}"rc
+          echo "source ~/.rit_completion" >> ~/."${SHELL_TYPE}"rc
+        fi
+
+    elif [ -f ${HOME}"/."${SHELL_TYPE}"_profile" ]; then
+
+        sed -i'' -e '/source <(rit completion/d' ${HOME}"/."${SHELL_TYPE}"_profile"
+
+        if grep "[[ -r "/usr/local/bin/rit" ]] && rit completion $SHELL_TYPE > ~/.rit_completion" ~/."${SHELL_TYPE}"_profile > /dev/null
+        then
+          echo ".${SHELL_TYPE}_profile IS ALREADY CONFIGURED TO SUPPORT RITCHIE AUTO COMPLETION"
+        else
+          echo "[[ -r "/usr/local/bin/rit" ]] && rit completion $SHELL_TYPE > ~/.rit_completion" >> ~/."${SHELL_TYPE}"_profile
+          echo "source ~/.rit_completion" >> ~/."${SHELL_TYPE}"_profile
+        fi
+
+    else
+      echo "Installed Ritchie without autocomplete"
+      return
+    fi
+
+
+      echo "Installed Ritchie with autocomplete"
+  fi
+}
+
+rit_install () {
+	echo "Downloading rit..."
+	STABLE_VERSION=$(curl -s https://commons-repo.ritchiecli.io/stable.txt)
+	curl -SLO "https://commons-repo.ritchiecli.io/${STABLE_VERSION}/${OPERATIONAL_SYSTEM}/rit"
+
+
+	chmod +x ./rit
+
+	INSTALL_PATH="/usr/local/bin"
+
+	if [ ! -d "$INSTALL_PATH" ]; then
+		sudo mkdir -p $INSTALL_PATH
+	fi
+
+	sudo mv ./rit $INSTALL_PATH/rit
+	$INSTALL_PATH/rit --version
+
+	idempotent_config
+}
+
+rit_identify_shell () {
+  if [ -n "$($SHELL -c 'echo $ZSH_VERSION')" ]; then
+    echo "Going to install autocomplete for zsh"
+    SHELL_TYPE="zsh"
+  elif [ -n "$($SHELL -c 'echo $BASH_VERSION')" ]; then
+    echo "Going to install autocomplete for bash"
+    SHELL_TYPE="bash"
+  else
+    echo "Please consider using bash or zsh to improve your ritchie experience"
+    SHELL_TYPE=""
+  fi
+}
+
+rit_identify_os () {
+
+  if [ $(uname) = "Linux" ]; then
+      echo "Installing Ritchie for Linux"
+      OPERATIONAL_SYSTEM="linux"
+  elif [ $(uname) = "Darwin" ]; then
+      echo "Installing Ritchie for Mac"
+      OPERATIONAL_SYSTEM="darwin"
+  else
+    echo "Unable to identify which OS you're using"
+    exit 1
+  fi
+}
+
+rit_install_jq () {
+  echo "Installing jq to work with json files..."
+  curl https://stedolan.github.io/jq/download/linux64/jq > /tmp/jq && chmod +x /tmp/jq
+}
+
+rit_rename_contexts_to_envs () {
+  echo "Converting context file to envs file..."
+
+  CURRENT_ENV=$(/tmp/jq .current_context < "$HOME"/.rit/contexts)
+  ENVS=$(/tmp/jq .contexts < "$HOME"/.rit/contexts)
+
+  echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
+}
+
+rit_remove_contexts_file () {
+  echo "Removing contexts file..."
+  rm -rf ~/.rit/contexts
+}
+
+rit_compatibility_script () {
+  if [ -f ~/.rit/contexts ]; then
+    echo "Running compatibility script..."
+    rit_install_jq
+    rit_rename_contexts_to_envs
+    rit_remove_contexts_file
+  fi
+}
+
+rit_identify_os
+
+rit_identify_shell
+
+rit_install
+
+rit_compatibility_script
+
+

--- a/install.sh
+++ b/install.sh
@@ -89,49 +89,8 @@ rit_identify_os () {
   fi
 }
 
-rit_install_jq () {
-  echo "Installing jq to work with json files..."
-  if [ $OPERATIONAL_SYSTEM = "linux" ]; then
-      curl https://stedolan.github.io/jq/download/linux64/jq > /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-  elif [ $OPERATIONAL_SYSTEM = "darwin" ]; then
-      brew install jq
-  else
-    echo "Unable to install jq"
-    exit 1
-  fi
-
-
-}
-
-rit_rename_contexts_to_envs () {
-  echo "Converting context file to envs file..."
-
-  CURRENT_ENV=$(jq .current_context < "$HOME"/.rit/contexts)
-  ENVS=$(jq .contexts < "$HOME"/.rit/contexts)
-
-  echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
-}
-
-rit_remove_contexts_file () {
-  echo "Removing contexts file..."
-  rm -rf ~/.rit/contexts
-}
-
-rit_compatibility_script () {
-  if [ -f ~/.rit/contexts ]; then
-    echo "Running compatibility script..."
-    rit_install_jq
-    rit_rename_contexts_to_envs
-    rit_remove_contexts_file
-  fi
-}
-
 rit_identify_os
 
 rit_identify_shell
 
 rit_install
-
-rit_compatibility_script
-
-

--- a/install.sh
+++ b/install.sh
@@ -91,14 +91,23 @@ rit_identify_os () {
 
 rit_install_jq () {
   echo "Installing jq to work with json files..."
-  curl https://stedolan.github.io/jq/download/linux64/jq > /tmp/jq && chmod +x /tmp/jq
+  if [ $OPERATIONAL_SYSTEM = "linux" ]; then
+      curl https://stedolan.github.io/jq/download/linux64/jq > /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+  elif [ $OPERATIONAL_SYSTEM = "darwin" ]; then
+      brew install jq
+  else
+    echo "Unable to install jq"
+    exit 1
+  fi
+
+
 }
 
 rit_rename_contexts_to_envs () {
   echo "Converting context file to envs file..."
 
-  CURRENT_ENV=$(/tmp/jq .current_context < "$HOME"/.rit/contexts)
-  ENVS=$(/tmp/jq .contexts < "$HOME"/.rit/contexts)
+  CURRENT_ENV=$(jq .current_context < "$HOME"/.rit/contexts)
+  ENVS=$(jq .contexts < "$HOME"/.rit/contexts)
 
   echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
 }

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -50,34 +50,5 @@ rit_identify_shell () {
   fi
 }
 
-rit_install_jq () {
-  echo "Installing jq to work with json files..."
-  curl https://stedolan.github.io/jq/download/linux64/jq > /tmp/jq && chmod +x /tmp/jq
-}
-
-rit_rename_contexts_to_envs () {
-  echo "Converting context file to envs file..."
-
-  CURRENT_ENV=$(/tmp/jq .current_context < "$HOME"/.rit/contexts)
-  ENVS=$(/tmp/jq .contexts < "$HOME"/.rit/contexts)
-
-  echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
-}
-
-rit_remove_contexts_file () {
-  echo "Removing contexts file..."
-  rm -rf ~/.rit/contexts
-}
-
-rit_compatibility_script () {
-  if [ -f ~/.rit/contexts ]; then
-    echo "Running compatibility script..."
-    rit_install_jq
-    rit_rename_contexts_to_envs
-    rit_remove_contexts_file
-  fi
-}
-
 rit_identify_shell
 idempotent_config
-rit_compatibility_script

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -52,21 +52,14 @@ rit_identify_shell () {
 
 rit_install_jq () {
   echo "Installing jq to work with json files..."
-  if [ "$(uname)" = "Linux" ]; then
-      curl https://stedolan.github.io/jq/download/linux64/jq > ./jq && chmod +x ./jq && sudo mv ./jq /usr/local/bin/jq
-  elif [ "$(uname)" = "Darwin" ]; then
-      brew install jq
-  else
-    echo "Unable to identify which OS you're using"
-    exit 1
-  fi
+  curl https://stedolan.github.io/jq/download/linux64/jq > /tmp/jq && chmod +x /tmp/jq
 }
 
 rit_rename_contexts_to_envs () {
   echo "Converting context file to envs file..."
 
-  CURRENT_ENV=$(cat ~/.rit/contexts | jq .current_context)
-  ENVS=$(cat ~/.rit/contexts | jq .contexts)
+  CURRENT_ENV=$(/tmp/jq .current_context < "$HOME"/.rit/contexts)
+  ENVS=$(/tmp/jq .contexts < "$HOME"/.rit/contexts)
 
   echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
 }

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -50,5 +50,41 @@ rit_identify_shell () {
   fi
 }
 
+rit_install_jq () {
+  echo "Installing jq to work with json files..."
+  if [ "$(uname)" = "Linux" ]; then
+      curl https://stedolan.github.io/jq/download/linux64/jq > ./jq && chmod +x ./jq && sudo mv ./jq /usr/local/bin/jq
+  elif [ "$(uname)" = "Darwin" ]; then
+      brew install jq
+  else
+    echo "Unable to identify which OS you're using"
+    exit 1
+  fi
+}
+
+rit_rename_contexts_to_envs () {
+  echo "Converting context file to envs file..."
+
+  CURRENT_ENV=$(cat ~/.rit/contexts | jq .current_context)
+  ENVS=$(cat ~/.rit/contexts | jq .contexts)
+
+  echo "{\"current_env\": $CURRENT_ENV, \"envs\": $ENVS}" > ~/.rit/envs
+}
+
+rit_remove_contexts_file () {
+  echo "Removing contexts file..."
+  rm -rf ~/.rit/contexts
+}
+
+rit_compatibility_script () {
+  if [ -f ~/.rit/contexts ]; then
+    echo "Running compatibility script..."
+    rit_install_jq
+    rit_rename_contexts_to_envs
+    rit_remove_contexts_file
+  fi
+}
+
 rit_identify_shell
 idempotent_config
+rit_compatibility_script

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -27,8 +27,9 @@ func buildStableBodyMock(expiresAt int64) []byte {
 
 func Test_rootCmd(t *testing.T) {
 	type in struct {
-		dir stream.DirCreateChecker
-		vm  version.Manager
+		dir  stream.DirCreateChecker
+		file stream.FileWriteReadExistRemover
+		vm   version.Manager
 	}
 
 	notExpiredCache := time.Now().Add(time.Hour).Unix()
@@ -61,7 +62,8 @@ func Test_rootCmd(t *testing.T) {
 						return nil
 					},
 				},
-				vm: versionManager,
+				file: stream.NewFileManager(),
+				vm:   versionManager,
 			},
 		},
 	}
@@ -69,7 +71,7 @@ func Test_rootCmd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := os.TempDir()
-			rootCmd := NewRootCmd(tmpDir, tt.in.dir, TutorialFinderMock{}, tt.in.vm)
+			rootCmd := NewRootCmd(tmpDir, tt.in.dir, tt.in.file, TutorialFinderMock{}, tt.in.vm)
 
 			if err := rootCmd.Execute(); (err != nil) != tt.wantErr {
 				t.Errorf("root error = %v | error wanted: %v", err, tt.wantErr)

--- a/pkg/commands/builder.go
+++ b/pkg/commands/builder.go
@@ -178,7 +178,7 @@ func Build() *cobra.Command {
 	upgradeDefaultUpdater := upgrade.NewDefaultUpdater()
 	upgradeManager := upgrade.NewDefaultManager(upgradeDefaultUpdater)
 	defaultUrlFinder := upgrade.NewDefaultUrlFinder(versionManager)
-	rootCmd := cmd.NewRootCmd(ritchieHomeDir, dirManager, tutorialFinder, versionManager)
+	rootCmd := cmd.NewRootCmd(ritchieHomeDir, dirManager, fileManager, tutorialFinder, versionManager)
 
 	// level 1
 	autocompleteCmd := cmd.NewAutocompleteCmd()


### PR DESCRIPTION
### Description
To maintain compatibility with old versions of rit we had to convert the file with the name of contexts for envs.

- Adding install.sh to the repository.
- Created context file converter for environments

### How to verify it
It's a small part of the #554 issue, a separate pull request was created to facilitate code review
