### PR TITLE
Fix update repo when all option selected

### DIFF
--- a/pkg/cmd/update_repo.go
+++ b/pkg/cmd/update_repo.go
@@ -88,9 +88,11 @@ func (up updateRepoCmd) runPrompt() CommandRunnerFunc {
 		}
 
 		var reposName []string
+		var externalRepos formula.Repos
 		reposName = append(reposName, updateOptionAll)
 		for i := range repos {
 			if !repos[i].IsLocal {
+				externalRepos = append(externalRepos, repos[i])
 				reposName = append(reposName, repos[i].Name.String())
 			}
 		}
@@ -106,9 +108,9 @@ func (up updateRepoCmd) runPrompt() CommandRunnerFunc {
 		var repoToUpdate []formula.Repo
 
 		if flagAll {
-			repoToUpdate = repos
+			repoToUpdate = externalRepos
 		} else {
-			for i := range repos {
+			for i := range externalRepos {
 				if repos[i].Name == formula.RepoName(name) {
 					repoToUpdate = append(repoToUpdate, repos[i])
 					break

--- a/pkg/cmd/update_repo_test.go
+++ b/pkg/cmd/update_repo_test.go
@@ -54,6 +54,7 @@ func TestUpdateRepoRun(t *testing.T) {
 		Url:      "https://github.com/owner/repo",
 		Token:    "token",
 		Priority: 1,
+		IsLocal:  true,
 	}
 
 	type in struct {


### PR DESCRIPTION
Signed-off-by: Bruna Tavares <bruna.silva@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
This pr fixes the bug in the rit update repo command, when using the all option.

Before
![image](https://user-images.githubusercontent.com/67295691/100666646-12b57880-3338-11eb-8331-b933828417d8.png)


After
![image](https://user-images.githubusercontent.com/67295691/100666529-ed286f00-3337-11eb-8507-0cde9148831b.png)


This pr 

### How to verify it

Use `rit update repo` and select 'all`.

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Fix rit update repo command
