### PR TITLE
Fix bug add repo when use stdin on windows

### DIFF
--- a/pkg/formula/input/stdin/stdin_test.go
+++ b/pkg/formula/input/stdin/stdin_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
-	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
 )
 
@@ -135,7 +134,7 @@ func TestInputManager_Inputs(t *testing.T) {
 				stdin:       `"sample_text"`,
 				file:        fileManager,
 			},
-			want: stdin.ErrInvalidInput,
+			want: errors.New("json: cannot unmarshal string into Go value of type map[string]interface {}"),
 		},
 		{
 			name: "error env resolver stdin",

--- a/pkg/formula/repo.go
+++ b/pkg/formula/repo.go
@@ -23,7 +23,7 @@ const RepoCommonsName = RepoName("commons")
 type Repo struct {
 	Provider RepoProvider `json:"provider"`
 	Name     RepoName     `json:"name"`
-	Version  RepoVersion  `json:"version"`
+	Version  RepoVersion  `json:"version,omitempty"`
 	Url      string       `json:"url"`
 	Token    string       `json:"token,omitempty"`
 	Priority int          `json:"priority"`

--- a/pkg/stdin/stdin.go
+++ b/pkg/stdin/stdin.go
@@ -18,16 +18,15 @@ package stdin
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 )
 
-var ErrInvalidInput = errors.New("the STDIN inputs weren't informed correctly. Check the JSON used to execute the command")
+// var ErrInvalidInput = errors.New("the STDIN inputs weren't informed correctly. Check the JSON used to execute the command")
 
 // ReadJson reads the json from stdin inputs
 func ReadJson(reader io.Reader, v interface{}) error {
 	if err := json.NewDecoder(reader).Decode(v); err != nil {
-		return ErrInvalidInput
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Bruna Tavares <bruna.silva@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->

When we use the rit add repo command without adding the version on windows, the behavior is incorrect (complains about json)

![image](https://user-images.githubusercontent.com/67295691/100668817-4645d200-333b-11eb-918a-91101479b52e.png)


### How to verify it

In windows, use rit add repo with stdin and not include version: `echo '{"provider":"Github", "name":"repoName", "url":"https://github.com/ZupIT/ritchie-formulas", "token": null, "priority":1}' | rit add repo --stdin`

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
