### PR TITLE
Deprecating stdin

### DIFF
--- a/functional/runner.go
+++ b/functional/runner.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 
 	"github.com/onsi/ginkgo"
+
+	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 )
 
 const (
@@ -60,6 +62,8 @@ func (scenario *Scenario) RunSteps() (string, error) {
 }
 
 func (scenario *Scenario) RunStdin() (string, error) {
+	prompt.Warning("stdin commands are deprecated and will no longer be supported, " +
+		"please use flags in the future")
 	fmt.Println("Running STDIN: " + scenario.Entry)
 	if windows {
 		b2, err := scenario.runStdinForWindows()

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -20,7 +20,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ZupIT/ritchie-cli/pkg/api"
+	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 )
+
+const stdinWarning = "stdin commands are deprecated and will no longer be supported in future versions. Please use" +
+	"flags for programatic formula execution"
 
 // CommandRunnerFunc represents that runner func for commands.
 type CommandRunnerFunc func(cmd *cobra.Command, args []string) error
@@ -34,6 +38,7 @@ func RunFuncE(stdinFunc, promptFunc CommandRunnerFunc) CommandRunnerFunc {
 		}
 
 		if stdin {
+			prompt.Warning(stdinWarning)
 			return stdinFunc(cmd, args)
 		}
 		return promptFunc(cmd, args)

--- a/pkg/formula/runner/input_resolver.go
+++ b/pkg/formula/runner/input_resolver.go
@@ -39,6 +39,9 @@ func (r Resolver) Resolve(inType api.TermInputType) (formula.InputRunner, error)
 	if inputRunner == nil {
 		return nil, ErrInputNotRecognized
 	}
+	if inType == api.Stdin {
+		prompt.Warning("stdin input is deprecated. Please use flags for programatic formula execution")
+	}
 
 	return inputRunner, nil
 }


### PR DESCRIPTION
Signed-off-by: Henrique Moraes <henrique.moraes@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
The team has decided that stdin inputs will be deprecated in favor of flags

### How to verify it
Stdin commands should issue a warning

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Deprecated stdin command
