### PR TITLE
Rename context to env

### DIFF
--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -23,11 +23,11 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
 )
 
-type ContextFinderMock struct {
+type EnvFinderMock struct {
 	mock.Mock
 }
 
-func (cf *ContextFinderMock) Find() (env.Holder, error) {
+func (cf *EnvFinderMock) Find() (env.Holder, error) {
 	args := cf.Called()
 
 	return args.Get(0).(env.Holder), args.Error(1)

--- a/pkg/cmd/delete_credential.go
+++ b/pkg/cmd/delete_credential.go
@@ -45,7 +45,7 @@ func NewDeleteCredentialCmd(
 	cmd := &cobra.Command{
 		Use:       "credential",
 		Short:     "Delete credential",
-		Long:      `Delete credential from current context`,
+		Long:      `Delete credential from current env`,
 		RunE:      RunFuncE(s.runStdin(), s.runPrompt()),
 		ValidArgs: []string{""},
 		Args:      cobra.OnlyValidArgs,
@@ -56,19 +56,19 @@ func NewDeleteCredentialCmd(
 
 func (d deleteCredentialCmd) runPrompt() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		context, err := d.currentEnv()
+		env, err := d.currentEnv()
 		if err != nil {
 			return err
 		}
-		prompt.Info(fmt.Sprintf("Current context: %s", context))
+		prompt.Info(fmt.Sprintf("Current env: %s", env))
 
-		data, err := d.ReadCredentialsValueInContext(d.CredentialsPath(), context)
+		data, err := d.ReadCredentialsValueInEnv(d.CredentialsPath(), env)
 		if err != nil {
 			return err
 		}
 
 		if len(data) <= 0 {
-			prompt.Error("You have no defined credentials in this context")
+			prompt.Error("You have no defined credentials in this env")
 			return nil
 		}
 
@@ -104,12 +104,12 @@ func (d deleteCredentialCmd) runStdin() CommandRunnerFunc {
 			return err
 		}
 
-		context, err := d.currentEnv()
+		env, err := d.currentEnv()
 		if err != nil {
 			return err
 		}
 
-		data, err := d.ReadCredentialsValueInContext(d.CredentialsPath(), context)
+		data, err := d.ReadCredentialsValueInEnv(d.CredentialsPath(), env)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/delete_credential_test.go
+++ b/pkg/cmd/delete_credential_test.go
@@ -52,8 +52,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "github", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "github", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{
@@ -67,14 +67,14 @@ func TestDeleteCredential(t *testing.T) {
 			inputStdin: createJSONEntry(stdinTest),
 		},
 		{
-			name:    "error on find context",
+			name:    "error on find env",
 			wantErr: true,
 			fields: fieldsTestDeleteCredentialCmd{
 				credDelete: credDeleteMock{},
 				reader:     credSettingsMock{},
 				envFinder: envFinderCustomMock{
 					find: func() (env.Holder, error) {
-						return env.Holder{}, errors.New("some error on find Context")
+						return env.Holder{}, errors.New("some error on find env")
 					},
 				},
 				inputBool: inputTrueMock{},
@@ -91,7 +91,7 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
 						return []credential.ListCredData{}, errors.New("ReadCredentialsValue error")
 					},
 				},
@@ -106,7 +106,7 @@ func TestDeleteCredential(t *testing.T) {
 			inputStdin: createJSONEntry(stdinTest),
 		},
 		{
-			name:    "error when there are no credentials in the context",
+			name:    "error when there are no credentials in the env",
 			wantErr: false,
 			fields: fieldsTestDeleteCredentialCmd{
 				credDelete: credDeleteMock{},
@@ -114,7 +114,7 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
 						return []credential.ListCredData{}, nil
 					},
 				},
@@ -137,8 +137,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "github", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "github", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{
@@ -160,8 +160,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "github", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "github", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{
@@ -183,8 +183,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "github", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "github", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{
@@ -210,8 +210,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "github", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "github", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{
@@ -233,8 +233,8 @@ func TestDeleteCredential(t *testing.T) {
 					CredentialsPathMock: func() string {
 						return ""
 					},
-					ReadCredentialsValueInContextMock: func(path string, context string) ([]credential.ListCredData, error) {
-						return []credential.ListCredData{{Provider: "gitlab", Context: "default", Credential: "{}"}}, nil
+					ReadCredentialsValueInEnvMock: func(path string, env string) ([]credential.ListCredData, error) {
+						return []credential.ListCredData{{Provider: "gitlab", Env: "default", Credential: "{}"}}, nil
 					},
 				},
 				envFinder: envFinderCustomMock{

--- a/pkg/cmd/delete_env_test.go
+++ b/pkg/cmd/delete_env_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 )
 
-func TestNewDeleteContextCmd(t *testing.T) {
+func TestNewDeleteEnvCmd(t *testing.T) {
 	findRemoverMock := envFindRemoverMock{holder: env.Holder{
 		Current: "",
 		All:     []string{"prod", "qa"},

--- a/pkg/cmd/list_credential.go
+++ b/pkg/cmd/list_credential.go
@@ -61,12 +61,12 @@ func printCredentialsTable(fields credential.ListCredDatas) {
 	table.Wrap = true
 	table.AddRow(
 		prompt.Bold("PROVIDER"),
-		prompt.Bold("CONTEXT"),
+		prompt.Bold("ENV"),
 		prompt.Bold("CREDENTIAL"),
 	)
 
 	for _, c := range fields {
-		table.AddRow(c.Provider, c.Context, c.Credential)
+		table.AddRow(c.Provider, c.Env, c.Credential)
 	}
 	if len(table.Rows) < 2 {
 		setCmd := prompt.Cyan("rit set credential")

--- a/pkg/cmd/list_credential_test.go
+++ b/pkg/cmd/list_credential_test.go
@@ -39,7 +39,7 @@ func Test_ListCredentialCmd(t *testing.T) {
 					credData := credential.ListCredData{
 						Provider:   "",
 						Credential: "",
-						Context:    "",
+						Env:        "",
 					}
 					credDataArr := []credential.ListCredData{credData}
 					return credDataArr, nil

--- a/pkg/cmd/mocks_test.go
+++ b/pkg/cmd/mocks_test.go
@@ -206,9 +206,9 @@ func (workspaceForm) Validate(workspace formula.Workspace) error {
 	return nil
 }
 
-type ctxSetterMock struct{}
+type envSetterMock struct{}
 
-func (ctxSetterMock) Set(ctx string) (env.Holder, error) {
+func (envSetterMock) Set(_ string) (env.Holder, error) {
 	return env.Holder{}, nil
 }
 
@@ -235,7 +235,7 @@ func (e envFindRemoverMock) Find() (env.Holder, error) {
 	return e.holder, e.err
 }
 
-func (envFindRemoverMock) Remove(ctx string) (env.Holder, error) {
+func (envFindRemoverMock) Remove(_ string) (env.Holder, error) {
 	return env.Holder{}, nil
 }
 
@@ -246,9 +246,9 @@ func (envFindSetterMock) Find() (env.Holder, error) {
 	return f.Find()
 }
 
-func (envFindSetterMock) Set(ctx string) (env.Holder, error) {
-	s := ctxSetterMock{}
-	return s.Set(ctx)
+func (envFindSetterMock) Set(env string) (env.Holder, error) {
+	s := envSetterMock{}
+	return s.Set(env)
 }
 
 type repoListerMock struct{}
@@ -306,7 +306,7 @@ func (s credSettingsMock) ReadCredentialsValue(path string) ([]credential.ListCr
 	return []credential.ListCredData{}, nil
 }
 
-func (s credSettingsMock) ReadCredentialsValueInContext(path string, context string) ([]credential.ListCredData, error) {
+func (s credSettingsMock) ReadCredentialsValueInEnv(path string, env string) ([]credential.ListCredData, error) {
 	return []credential.ListCredData{}, nil
 }
 
@@ -328,7 +328,7 @@ func (s credSettingsMock) CredentialsPath() string {
 
 type credSettingsCustomMock struct {
 	ReadCredentialsValueMock          func(path string) ([]credential.ListCredData, error)
-	ReadCredentialsValueInContextMock func(path string, context string) ([]credential.ListCredData, error)
+	ReadCredentialsValueInEnvMock     func(path string, env string) ([]credential.ListCredData, error)
 	ReadCredentialsFieldsMock         func(path string) (credential.Fields, error)
 	WriteDefaultCredentialsFieldsMock func(path string) error
 	WriteCredentialsFieldsMock        func(fields credential.Fields, path string) error
@@ -344,8 +344,8 @@ func (cscm credSettingsCustomMock) ReadCredentialsValue(path string) ([]credenti
 	return cscm.ReadCredentialsValueMock(path)
 }
 
-func (cscm credSettingsCustomMock) ReadCredentialsValueInContext(path string, context string) ([]credential.ListCredData, error) {
-	return cscm.ReadCredentialsValueInContextMock(path, context)
+func (cscm credSettingsCustomMock) ReadCredentialsValueInEnv(path string, env string) ([]credential.ListCredData, error) {
+	return cscm.ReadCredentialsValueInEnvMock(path, env)
 }
 
 func (cscm credSettingsCustomMock) WriteDefaultCredentialsFields(path string) error {

--- a/pkg/cmd/show_env_test.go
+++ b/pkg/cmd/show_env_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestNewShowContextCmd(t *testing.T) {
+func TestNewShowEnvCmd(t *testing.T) {
 	cmd := NewShowEnvCmd(envFinderMock{})
 	if cmd == nil {
 		t.Errorf("NewShowEnvCmd got %v", cmd)

--- a/pkg/commands/builder.go
+++ b/pkg/commands/builder.go
@@ -116,14 +116,14 @@ func Build() *cobra.Command {
 	detailRepo := repo.NewDetail(repoProviders)
 
 	tplManager := template.NewManager(api.RitchieHomeDir(), dirManager)
-	ctxFinder := env.NewFinder(ritchieHomeDir, fileManager)
-	ctxSetter := env.NewSetter(ritchieHomeDir, ctxFinder, fileManager)
-	ctxRemover := env.NewRemover(ritchieHomeDir, ctxFinder, fileManager)
-	ctxFindSetter := env.NewFindSetter(ctxFinder, ctxSetter)
-	ctxFindRemover := env.NewFindRemover(ctxFinder, ctxRemover)
-	credSetter := credential.NewSetter(ritchieHomeDir, ctxFinder, dirManager, fileManager)
-	credFinder := credential.NewFinder(ritchieHomeDir, ctxFinder, fileManager)
-	credDeleter := credential.NewCredDelete(ritchieHomeDir, ctxFinder, fileManager)
+	envFinder := env.NewFinder(ritchieHomeDir, fileManager)
+	envSetter := env.NewSetter(ritchieHomeDir, envFinder, fileManager)
+	envRemover := env.NewRemover(ritchieHomeDir, envFinder, fileManager)
+	envFindSetter := env.NewFindSetter(envFinder, envSetter)
+	envFindRemover := env.NewFindRemover(envFinder, envRemover)
+	credSetter := credential.NewSetter(ritchieHomeDir, envFinder, dirManager, fileManager)
+	credFinder := credential.NewFinder(ritchieHomeDir, envFinder, fileManager)
+	credDeleter := credential.NewCredDelete(ritchieHomeDir, envFinder, fileManager)
 	credSettings := credential.NewSettings(fileManager, dirManager, userHomeDir)
 	treeManager := tree.NewTreeManager(ritchieHomeDir, repoLister, api.CoreCmds, fileManager, repoProviders, isRootCommand)
 	treeChecker := tree.NewChecker(treeManager)
@@ -153,10 +153,10 @@ func Build() *cobra.Command {
 	inputResolver := runner.NewInputResolver(termInputTypes)
 
 	formulaLocalPreRun := local.NewPreRun(ritchieHomeDir, formBuildMake, formBuildBat, formBuildSh, dirManager, fileManager)
-	formulaLocalRun := local.NewRunner(postRunner, inputResolver, formulaLocalPreRun, fileManager, ctxFinder, userHomeDir)
+	formulaLocalRun := local.NewRunner(postRunner, inputResolver, formulaLocalPreRun, fileManager, envFinder, userHomeDir)
 
 	formulaDockerPreRun := docker.NewPreRun(ritchieHomeDir, formBuildDocker, dirManager, fileManager)
-	formulaDockerRun := docker.NewRunner(postRunner, inputResolver, formulaDockerPreRun, fileManager, ctxFinder, userHomeDir)
+	formulaDockerRun := docker.NewRunner(postRunner, inputResolver, formulaDockerPreRun, fileManager, envFinder, userHomeDir)
 
 	runners := formula.Runners{
 		formula.LocalRun:  formulaLocalRun,
@@ -209,14 +209,14 @@ func Build() *cobra.Command {
 	deleteCredentialCmd := cmd.NewDeleteCredentialCmd(
 		credDeleter,
 		credSettings,
-		ctxFinder,
+		envFinder,
 		inputBool,
 		inputList,
 	)
 
-	deleteCtxCmd := cmd.NewDeleteEnvCmd(ctxFindRemover, inputBool, inputList)
-	setCtxCmd := cmd.NewSetEnvCmd(ctxFindSetter, inputText, inputList)
-	showCtxCmd := cmd.NewShowEnvCmd(ctxFinder)
+	deleteEnvCmd := cmd.NewDeleteEnvCmd(envFindRemover, inputBool, inputList)
+	setEnvCmd := cmd.NewSetEnvCmd(envFindSetter, inputText, inputList)
+	showEnvCmd := cmd.NewShowEnvCmd(envFinder)
 	addRepoCmd := cmd.NewAddRepoCmd(repoAddLister, repoProviders, inputTextValidator, inputPassword, inputURL, inputList, inputBool, inputInt, tutorialFinder, treeChecker, detailRepo)
 
 	updateRepoCmd := cmd.NewUpdateRepoCmd(http.DefaultClient, repoListUpdater, repoProviders, inputText, inputPassword, inputURL, inputList, inputBool, inputInt)
@@ -240,12 +240,12 @@ func Build() *cobra.Command {
 	addCmd.AddCommand(addRepoCmd)
 	updateCmd.AddCommand(updateRepoCmd)
 	createCmd.AddCommand(createFormulaCmd)
-	deleteCmd.AddCommand(deleteCtxCmd, deleteRepoCmd, deleteFormulaCmd, deleteWorkspaceCmd, deleteCredentialCmd)
+	deleteCmd.AddCommand(deleteEnvCmd, deleteRepoCmd, deleteFormulaCmd, deleteWorkspaceCmd, deleteCredentialCmd)
 	listCmd.AddCommand(listRepoCmd)
 	listCmd.AddCommand(listCredentialCmd)
 	listCmd.AddCommand(listWorkspaceCmd)
-	setCmd.AddCommand(setCredentialCmd, setCtxCmd, setPriorityCmd, setFormulaRunnerCmd)
-	showCmd.AddCommand(showCtxCmd, showFormulaRunnerCmd)
+	setCmd.AddCommand(setCredentialCmd, setEnvCmd, setPriorityCmd, setFormulaRunnerCmd)
+	showCmd.AddCommand(showEnvCmd, showFormulaRunnerCmd)
 	buildCmd.AddCommand(buildFormulaCmd)
 
 	formulaCmd := cmd.NewFormulaCommand(api.CoreCmds, treeManager, formulaExec, fileManager)

--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -44,7 +44,7 @@ type ListCredDatas []ListCredData
 type ListCredData struct {
 	Provider   string
 	Credential string
-	Context    string
+	Env        string
 }
 
 // Fields are used to represents providers.json
@@ -65,7 +65,7 @@ type CredDelete interface {
 type Reader interface {
 	ReadCredentialsFields(path string) (Fields, error)
 	ReadCredentialsValue(path string) ([]ListCredData, error)
-	ReadCredentialsValueInContext(path string, context string) ([]ListCredData, error)
+	ReadCredentialsValueInEnv(path string, env string) ([]ListCredData, error)
 }
 
 type Writer interface {

--- a/pkg/credential/resolver_test.go
+++ b/pkg/credential/resolver_test.go
@@ -31,9 +31,9 @@ func TestCredentialResolver(t *testing.T) {
 	fileManager := stream.NewFileManager()
 	dirManager := stream.NewDirManager(fileManager)
 	tempDirectory := os.TempDir()
-	contextFinder := env.NewFinder(tempDirectory, fileManager)
-	credentialSetter := NewSetter(tempDirectory, contextFinder, dirManager, fileManager)
-	credentialFinder := NewFinder(tempDirectory, contextFinder, fileManager)
+	envFinder := env.NewFinder(tempDirectory, fileManager)
+	credentialSetter := NewSetter(tempDirectory, envFinder, dirManager, fileManager)
+	credentialFinder := NewFinder(tempDirectory, envFinder, fileManager)
 
 	defer os.RemoveAll(File(tempDirectory, "", ""))
 

--- a/pkg/credential/setter_test.go
+++ b/pkg/credential/setter_test.go
@@ -67,17 +67,17 @@ func (suite *SetterTestSuite) fileInfo(path string) (string, error) {
 func (suite *SetterTestSuite) TestSetCredentialToDefault() {
 	for _, t := range []struct {
 		testName string
-		context  env.Holder
+		env      env.Holder
 	}{
-		{"Context informed", *suite.envHolderDefault},
-		{"Context not informed", *suite.envHolderNil},
+		{"env informed", *suite.envHolderDefault},
+		{"env not informed", *suite.envHolderNil},
 	} {
 		suite.Run(t.testName, func() {
-			contextFinderMock := new(mocks.ContextFinderMock)
+			envFinderMock := new(mocks.EnvFinderMock)
 			filePathExpectedCreated := File(suite.HomePath, suite.envHolderDefault.Current, suite.DetailCredentialInfo.Service)
 
-			contextFinderMock.On("Find").Return(t.context, nil)
-			setter := NewSetter(suite.HomePath, contextFinderMock, dirManager, fileManager)
+			envFinderMock.On("Find").Return(t.env, nil)
+			setter := NewSetter(suite.HomePath, envFinderMock, dirManager, fileManager)
 
 			suite.NoFileExists(filePathExpectedCreated)
 

--- a/pkg/credential/settings.go
+++ b/pkg/credential/settings.go
@@ -55,17 +55,17 @@ func (s Settings) ReadCredentialsValue(path string) ([]ListCredData, error) {
 	var creds []ListCredData
 	var cred ListCredData
 	var detail Detail
-	ctx, _ := s.dir.List(path, true)
-	for _, c := range ctx {
-		providers, _ := s.file.List(filepath.Join(path, c))
+	envs, _ := s.dir.List(path, true)
+	for _, env := range envs {
+		providers, _ := s.file.List(filepath.Join(path, env))
 		for _, p := range providers {
-			cBytes, _ := s.file.Read(filepath.Join(path, c, p))
+			cBytes, _ := s.file.Read(filepath.Join(path, env, p))
 			if err := json.Unmarshal(cBytes, &detail); err != nil {
 				return creds, err
 			}
 			cred.Credential = formatCredential(string(cBytes))
 			cred.Provider = detail.Service
-			cred.Context = c
+			cred.Env = env
 			creds = append(creds, cred)
 			detail = Detail{}
 		}
@@ -73,19 +73,19 @@ func (s Settings) ReadCredentialsValue(path string) ([]ListCredData, error) {
 	return creds, nil
 }
 
-func (s Settings) ReadCredentialsValueInContext(path string, context string) ([]ListCredData, error) {
+func (s Settings) ReadCredentialsValueInEnv(path string, env string) ([]ListCredData, error) {
 	var cred ListCredData
 	var detail Detail
-	providers, _ := s.file.List(filepath.Join(path, context))
+	providers, _ := s.file.List(filepath.Join(path, env))
 	creds := make([]ListCredData, 0, len(providers))
 	for _, p := range providers {
-		cBytes, _ := s.file.Read(filepath.Join(path, context, p))
+		cBytes, _ := s.file.Read(filepath.Join(path, env, p))
 		if err := json.Unmarshal(cBytes, &detail); err != nil {
 			return creds, err
 		}
 		cred.Credential = formatCredential(string(cBytes))
 		cred.Provider = detail.Service
-		cred.Context = context
+		cred.Env = env
 		creds = append(creds, cred)
 		detail = Detail{}
 	}

--- a/pkg/credential/settings_test.go
+++ b/pkg/credential/settings_test.go
@@ -80,31 +80,31 @@ func TestSettings_ReadCredentialsValue(t *testing.T) {
 	}
 }
 
-func TestSettings_ReadCredentialsValueInContext(t *testing.T) {
+func TestSettings_ReadCredentialsValueInEnv(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		context string
+		env     string
 		wantErr bool
 	}{
 		{
 			name:    "run with success",
 			path:    "../../testdata/.rit/credentials/",
-			context: "default",
+			env:     "default",
 			wantErr: false,
 		},
 		{
 			name:    "error on json unmarshal",
 			path:    "../../testdata/.rit/credentialserr/",
-			context: "error",
+			env:     "error",
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credentials, err := credSettings.ReadCredentialsValueInContext(tt.path, tt.context)
+			credentials, err := credSettings.ReadCredentialsValueInEnv(tt.path, tt.env)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Read credentials value in context error = %s, wantErr %v", err, tt.wantErr)
+				t.Errorf("Read credentials value in env error = %s, wantErr %v", err, tt.wantErr)
 			}
 
 			if (credentials == nil || len(credentials) <= 0) != tt.wantErr {

--- a/pkg/formula/formula.go
+++ b/pkg/formula/formula.go
@@ -35,6 +35,7 @@ const (
 	DefaultConfig      = "config.json"
 	PwdEnv             = "CURRENT_PWD"
 	CtxEnv             = "CONTEXT"
+	Env                = "ENVIRONMENT"
 	VerboseEnv         = "VERBOSE_MODE"
 	DockerExecutionEnv = "DOCKER_EXECUTION"
 	BinUnix            = "run.sh"

--- a/pkg/formula/runner/docker/runner.go
+++ b/pkg/formula/runner/docker/runner.go
@@ -158,8 +158,9 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "true")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)
 	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, envHolder.Current)
+	env := fmt.Sprintf(formula.EnvPattern, formula.Env, envHolder.Current)
 	verboseEnv := fmt.Sprintf(formula.EnvPattern, formula.VerboseEnv, strconv.FormatBool(verbose))
-	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv)
+	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv, env)
 
 	for _, e := range cmd.Env { // Create a file named .envHolder and add the environment variable inName=inValue
 		if !ru.file.Exists(envFile) {

--- a/pkg/formula/runner/docker/runner_test.go
+++ b/pkg/formula/runner/docker/runner_test.go
@@ -50,7 +50,7 @@ func TestRun(t *testing.T) {
 	zipFile := filepath.Join("..", "..", "..", "..", "testdata", "ritchie-formulas-test.zip")
 	_ = streams.Unzip(zipFile, repoPath)
 
-	ctxFinder := env.NewFinder(ritHome, fileManager)
+	envFinder := env.NewFinder(ritHome, fileManager)
 	preRunner := NewPreRun(ritHome, dockerBuilder, dirManager, fileManager)
 	postRunner := runner.NewPostRunner(fileManager, dirManager)
 	pInputRunner := prompt.NewInputManager(envResolverMock{in: "test"}, fileManager, inputMock{}, inputMock{}, inputTextValidatorMock{str: "test"}, inputTextDefaultMock{}, inputMock{}, inputMock{})
@@ -69,7 +69,7 @@ func TestRun(t *testing.T) {
 		preRun        formula.PreRunner
 		postRun       formula.PostRunner
 		inputResolver formula.InputResolver
-		context       env.Finder
+		env           env.Finder
 		fileManager   stream.FileWriteExistAppender
 	}
 
@@ -90,7 +90,7 @@ func TestRun(t *testing.T) {
 				postRun:       postRunner,
 				inputResolver: inputResolver,
 				fileManager:   fileManager,
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: nil,
@@ -104,7 +104,7 @@ func TestRun(t *testing.T) {
 				postRun:       postRunner,
 				inputResolver: inputResolverMock{err: runner.ErrInputNotRecognized},
 				fileManager:   fileManager,
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: runner.ErrInputNotRecognized,
@@ -118,7 +118,7 @@ func TestRun(t *testing.T) {
 				postRun:       postRunner,
 				inputResolver: inputResolver,
 				fileManager:   fileManager,
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: errors.New("pre runner error"),
@@ -132,7 +132,7 @@ func TestRun(t *testing.T) {
 				postRun:       postRunnerMock{err: errors.New("post runner error")},
 				inputResolver: inputResolver,
 				fileManager:   fileManager,
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: nil,
@@ -146,7 +146,7 @@ func TestRun(t *testing.T) {
 				postRun:       postRunner,
 				inputResolver: inputResolver,
 				fileManager:   fileManagerMock{wErr: errors.New("error to write env file")},
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: errors.New("error to write env file"),
@@ -160,24 +160,24 @@ func TestRun(t *testing.T) {
 				postRun:       postRunner,
 				inputResolver: inputResolver,
 				fileManager:   fileManagerMock{exist: true, aErr: errors.New("error to append env file")},
-				context:       ctxFinder,
+				env:           envFinder,
 			},
 			out: out{
 				err: errors.New("error to append env file"),
 			},
 		},
 		{
-			name: "context find error",
+			name: "env find error",
 			in: in{
 				def:           formula.Definition{Path: "testing/formula", RepoName: "commons"},
 				preRun:        preRunner,
 				postRun:       postRunner,
 				inputResolver: inputResolver,
 				fileManager:   fileManagerMock{exist: true, aErr: errors.New("error to append env file")},
-				context:       ctxFinderMock{err: errors.New("context not found")},
+				env:           envFinderMock{err: errors.New("env not found")},
 			},
 			out: out{
-				err: errors.New("context not found"),
+				err: errors.New("env not found"),
 			},
 		},
 	}
@@ -185,7 +185,7 @@ func TestRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			in := tt.in
-			docker := NewRunner(in.postRun, in.inputResolver, in.preRun, in.fileManager, in.context, homeDir)
+			docker := NewRunner(in.postRun, in.inputResolver, in.preRun, in.fileManager, in.env, homeDir)
 			got := docker.Run(in.def, api.Prompt, false, nil)
 
 			if tt.out.err != nil && got != nil && tt.out.err.Error() != got.Error() {
@@ -261,13 +261,13 @@ func (i inputTextDefaultMock) Text(formula.Input) (string, error) {
 	return i.text, i.err
 }
 
-type ctxFinderMock struct {
-	ctx env.Holder
+type envFinderMock struct {
+	env env.Holder
 	err error
 }
 
-func (c ctxFinderMock) Find() (env.Holder, error) {
-	return c.ctx, c.err
+func (c envFinderMock) Find() (env.Holder, error) {
+	return c.env, c.err
 }
 
 type inputResolverMock struct {

--- a/pkg/formula/runner/local/runner.go
+++ b/pkg/formula/runner/local/runner.go
@@ -120,8 +120,9 @@ func (ru RunManager) setEnvs(cmd *exec.Cmd, pwd string, verbose bool) error {
 	dockerEnv := fmt.Sprintf(formula.EnvPattern, formula.DockerExecutionEnv, "false")
 	pwdEnv := fmt.Sprintf(formula.EnvPattern, formula.PwdEnv, pwd)
 	ctxEnv := fmt.Sprintf(formula.EnvPattern, formula.CtxEnv, envHolder.Current)
+	env := fmt.Sprintf(formula.EnvPattern, formula.Env, envHolder.Current)
 	verboseEnv := fmt.Sprintf(formula.EnvPattern, formula.VerboseEnv, strconv.FormatBool(verbose))
-	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv)
+	cmd.Env = append(cmd.Env, pwdEnv, ctxEnv, verboseEnv, dockerEnv, env)
 
 	return nil
 }


### PR DESCRIPTION
### Description
Rename all methods and variables named context to env

### How to verify it
It's a small part of the #554 issue, a separate pull request was created to facilitate code review
