### PR TITLE
Fixing codecov patch at 80%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 coverage:
   status:
     project: off
+    patch:
+      default:
+        target: 80%
 github_checks:
   annotations: false
 ignore:


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
Codecov's patch check keeps comparing the project against its current coverage, which constantly enforces the coverage to become gradually higher. We are fixing the coverage at 80%, which is reasonable enough.

### How to verify it
Get a PR with 81% coverage and check if it passes, can you do it?

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Fixed project's coverage requirement at 80%
