### PR TITLE
Improve performance to "rit create formula" command

### DIFF
--- a/functional/stdin/stdin_feature.json
+++ b/functional/stdin/stdin_feature.json
@@ -141,7 +141,7 @@
                 "action": "main"
             }
         ],
-        "result": "Rit formula's command needs at least 2 words"
+        "result": "rit formula's command needs at least 2 words following \"rit\" [ex.: rit group verb]"
     },
     {
         "entry": "Create formula STDIN - no rit on formula name",
@@ -157,7 +157,7 @@
                 "action": "main"
             }
         ],
-        "result": "Rit formula's command needs to start with"
+        "result": "rit formula's command needs to start with \"rit\" [ex.: rit group verb <noun>]"
     },
     {
         "entry": "Create formula STDIN - not allowed char",
@@ -173,7 +173,7 @@
                 "action": "main"
             }
         ],
-        "result": "not allowed character on formula name"
+        "result": "these characters are not allowed in the formula command [\\ /,> <@ -]"
     },
     {
         "entry": "Create formula STDIN - core command after rit",

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/api"
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
+	"github.com/ZupIT/ritchie-cli/pkg/formula/creator/template"
 	"github.com/ZupIT/ritchie-cli/pkg/git"
 	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
 )
@@ -136,6 +137,15 @@ func (i *InputPasswordMock) Password(label string, helper ...string) (string, er
 	return args.String(0), args.Error(1)
 }
 
+type InputTextMock struct {
+	mock.Mock
+}
+
+func (i *InputTextMock) Text(name string, required bool, helper ...string) (string, error) {
+	args := i.Called(name, required, helper)
+	return args.String(0), args.Error(1)
+}
+
 type InputTextValidatorMock struct {
 	mock.Mock
 }
@@ -195,7 +205,7 @@ func (w *WorkspaceForm) PreviousHash(formulaPath string) (string, error) {
 }
 
 func (w *WorkspaceForm) UpdateHash(formulaPath string, hash string) error {
-	args := w.Called(formulaPath)
+	args := w.Called(formulaPath, hash)
 	return args.Error(0)
 }
 
@@ -319,4 +329,26 @@ func (t *TreeManager) Generate(repoPath string) (formula.Tree, error) {
 func (t *TreeManager) Check() []api.CommandID {
 	args := t.Called()
 	return args.Get(0).([]api.CommandID)
+}
+
+type TemplateManagerMock struct {
+	mock.Mock
+}
+
+func (tm *TemplateManagerMock) Languages() ([]string, error) {
+	args := tm.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (tm *TemplateManagerMock) LangTemplateFiles(lang string) ([]template.File, error) {
+	args := tm.Called(lang)
+	return args.Get(0).([]template.File), args.Error(1)
+}
+func (tm *TemplateManagerMock) ResolverNewPath(oldPath, newDir, lang, workspacePath string) (string, error) {
+	args := tm.Called(oldPath, newDir, lang, workspacePath)
+	return args.String(0), args.Error(1)
+}
+func (tm *TemplateManagerMock) Validate() error {
+	args := tm.Called()
+	return args.Error(0)
 }

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -344,10 +344,12 @@ func (tm *TemplateManagerMock) LangTemplateFiles(lang string) ([]template.File, 
 	args := tm.Called(lang)
 	return args.Get(0).([]template.File), args.Error(1)
 }
+
 func (tm *TemplateManagerMock) ResolverNewPath(oldPath, newDir, lang, workspacePath string) (string, error) {
 	args := tm.Called(oldPath, newDir, lang, workspacePath)
 	return args.String(0), args.Error(1)
 }
+
 func (tm *TemplateManagerMock) Validate() error {
 	args := tm.Called()
 	return args.Error(0)

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -160,3 +160,56 @@ func (i *InputTextValidatorMock) Text(name string, validate func(interface{}) er
 
 	return args.String(0), args.Error(1)
 }
+
+type FormCreator struct {
+	mock.Mock
+}
+
+func (f *FormCreator) Create(cf formula.Create) error {
+	args := f.Called(cf)
+	return args.Error(0)
+}
+
+func (f *FormCreator) Build(info formula.BuildInfo) error {
+	args := f.Called(info)
+	return args.Error(0)
+}
+
+type WorkspaceForm struct {
+	mock.Mock
+}
+
+func (w *WorkspaceForm) Add(workspace formula.Workspace) error {
+	args := w.Called(workspace)
+	return args.Error(0)
+}
+
+func (w *WorkspaceForm) Delete(workspace formula.Workspace) error {
+	args := w.Called(workspace)
+	return args.Error(0)
+}
+
+func (w *WorkspaceForm) List() (formula.Workspaces, error) {
+	args := w.Called()
+	return args.Get(0).(formula.Workspaces), args.Error(1)
+}
+
+func (w *WorkspaceForm) Validate(workspace formula.Workspace) error {
+	args := w.Called(workspace)
+	return args.Error(0)
+}
+
+func (w *WorkspaceForm) CurrentHash(formulaPath string) (string, error) {
+	args := w.Called(formulaPath)
+	return args.String(0), args.Error(1)
+}
+
+func (w *WorkspaceForm) PreviousHash(formulaPath string) (string, error) {
+	args := w.Called(formulaPath)
+	return args.String(0), args.Error(1)
+}
+
+func (w *WorkspaceForm) UpdateHash(formulaPath string, hash string) error {
+	args := w.Called(formulaPath)
+	return args.Error(0)
+}


### PR DESCRIPTION
### Description
Some versions ago we removed the building code of the `rit create formula` command because it is already present at the time of executing a formula, then we realized that we could remove the spinner of the `rit create formula` command. The command now executes instantly when called.

When creating the formula we now generate your hash to get to know if we had any changes to the formula before the first build was done.

### How to verify it
Follow the steps below:
- create a new formula
- edit this formula

The formula changes must be present in the first build.

### Changelog
Remove spinner from `rit create formula`