### PR TITLE
Fix add empty local repo

### DIFF
--- a/pkg/formula/repo/adder.go
+++ b/pkg/formula/repo/adder.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
 )
 
+var ErrInvalidRepo = errors.New("the selected repository has no formulas")
+
 type AddManager struct {
 	ritHome string
 	repo    formula.RepositoryListWriteCreator
@@ -82,11 +84,8 @@ func (ad AddManager) treeGenerate(repo formula.Repo) error {
 		return err
 	}
 
-	if len(tree.Commands) == 0 {
-		if err := ad.deleter.Delete(repo.Name); err != nil {
-			return err
-		}
-		return errors.New("the selected repository has no formulas")
+	if err := ad.isValidRepo(repo, tree); err != nil {
+		return err
 	}
 
 	treeFilePath := filepath.Join(newRepoPath, "tree.json")
@@ -99,6 +98,16 @@ func (ad AddManager) treeGenerate(repo formula.Repo) error {
 		return err
 	}
 
+	return nil
+}
+
+func (ad AddManager) isValidRepo(repo formula.Repo, tree formula.Tree) error {
+	if len(tree.Commands) == 0 && !repo.IsLocal {
+		if err := ad.deleter.Delete(repo.Name); err != nil {
+			return err
+		}
+		return ErrInvalidRepo
+	}
 	return nil
 }
 

--- a/pkg/formula/repo/adder_test.go
+++ b/pkg/formula/repo/adder_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ZupIT/ritchie-cli/pkg/api"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
@@ -45,7 +47,7 @@ func TestAdd(t *testing.T) {
 	tests := []struct {
 		name    string
 		in      in
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name: "Run with success, when repository json not exist",
@@ -83,7 +85,6 @@ func TestAdd(t *testing.T) {
 					Version:  "2.0",
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "Run with success, when repository json exist",
@@ -140,18 +141,17 @@ func TestAdd(t *testing.T) {
 					Version:  "2.0",
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "Return err when RepositoryCreator fail",
 			in: in{
 				repoMock: repoListWriteCreatorMock{
 					create: func(repo formula.Repo) error {
-						return errors.New("some error")
+						return errors.New("error to create repo")
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to create repo"),
 		},
 		{
 			name: "Return err when repos list fail",
@@ -168,7 +168,7 @@ func TestAdd(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to read repos file"),
 		},
 		{
 			name: "Return err when saveRepo fail",
@@ -181,11 +181,11 @@ func TestAdd(t *testing.T) {
 						return nil
 					},
 					write: func(repos formula.Repos) error {
-						return errors.New("some error")
+						return errors.New("error to write repo file")
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to write repo file"),
 		},
 		{
 			name: "Return err when tree Generate fail",
@@ -211,11 +211,11 @@ func TestAdd(t *testing.T) {
 				},
 				tree: treeGeneratorCustomMock{
 					func(repoPath string) (formula.Tree, error) {
-						return formula.Tree{}, errors.New("some error")
+						return formula.Tree{}, errors.New("error to generate tree.json")
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to generate tree.json"),
 		},
 		{
 			name: "Return err when write tree.json",
@@ -233,7 +233,7 @@ func TestAdd(t *testing.T) {
 				},
 				file: FileWriteCreatorReadExistRemover{
 					write: func(path string, content []byte) error {
-						return errors.New("some error")
+						return errors.New("error to write tree.json")
 					},
 				},
 				tree: treeGeneratorCustomMock{
@@ -242,7 +242,7 @@ func TestAdd(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to write tree.json"),
 		},
 		{
 			name: "Return err when tree.json has no commands",
@@ -269,7 +269,7 @@ func TestAdd(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: ErrInvalidRepo,
 		},
 		{
 			name: "Return err when Delete fail",
@@ -292,11 +292,50 @@ func TestAdd(t *testing.T) {
 				},
 				deleter: repositoryDeleterMock{
 					deleteMock: func(repoName formula.RepoName) error {
-						return errors.New("any error on Delete")
+						return errors.New("error to delete repository")
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("error to delete repository"),
+		},
+		{
+			name: "success when add a new empty local repository",
+			in: in{
+				repo: formula.Repo{
+					Provider: "Local",
+					Name:     formula.RepoName("my-repo"),
+					Version:  "0.0.0",
+					Url:      "local repository",
+					Priority: 0,
+					IsLocal:  true,
+				},
+				repoMock: repoListWriteCreatorMock{
+					list: func() (formula.Repos, error) {
+						return formula.Repos{}, nil
+					},
+					create: func(repo formula.Repo) error {
+						return nil
+					},
+					write: func(repos formula.Repos) error {
+						return nil
+					},
+				},
+				tree: treeGeneratorCustomMock{
+					func(repoPath string) (formula.Tree, error) {
+						return formula.Tree{}, nil
+					},
+				},
+				file: FileWriteCreatorReadExistRemover{
+					write: func(path string, content []byte) error {
+						return nil
+					},
+				},
+				deleter: repositoryDeleterMock{
+					deleteMock: func(repoName formula.RepoName) error {
+						return nil
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -308,9 +347,9 @@ func TestAdd(t *testing.T) {
 				tt.in.tree,
 				tt.in.file,
 			)
-			if err := ad.Add(tt.in.repo); (err != nil) != tt.wantErr {
-				t.Errorf("Add() error = %v, wantErr %v", err, tt.wantErr)
-			}
+
+			got := ad.Add(tt.in.repo)
+			assert.Equal(t, tt.wantErr, got)
 		})
 	}
 }


### PR DESCRIPTION
### Description

I added a new parameter in the add repository validation, now we will be able to add empty local repositories in the `rit create formula` command.

### How to verify it
Following the steps below:
- create a new empty folder
- create a new formula and add this empty folder as workspace

your formula must be created successfully!

### Changelog
Enable to add an empty local repository