### PR TITLE
Add flags to delete env

### DIFF
--- a/pkg/cmd/delete_env.go
+++ b/pkg/cmd/delete_env.go
@@ -48,7 +48,7 @@ var (
 	}
 )
 
-type inputDeleteEnv struct {
+type teste struct {
 	env string
 }
 
@@ -89,16 +89,16 @@ func NewDeleteEnvCmd(
 
 func (d *deleteEnvCmd) runFormula() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		inputParams, err := d.resolveInput(cmd)
+		env, err := d.resolveInput(cmd)
 		if err != nil {
 			return err
 		}
 
-		if inputParams.env == "" {
+		if env == "" {
 			return nil
 		}
 
-		if _, err := d.env.Remove(inputParams.env); err != nil {
+		if _, err := d.env.Remove(env); err != nil {
 			return err
 		}
 
@@ -134,22 +134,22 @@ func (d deleteEnvCmd) runStdin() CommandRunnerFunc {
 	}
 }
 
-func (d *deleteEnvCmd) resolveInput(cmd *cobra.Command) (inputDeleteEnv, error) {
+func (d *deleteEnvCmd) resolveInput(cmd *cobra.Command) (string, error) {
 	if IsFlagInput(cmd) {
 		return d.resolveFlags(cmd)
 	}
 	return d.resolvePrompt()
 }
 
-func (d *deleteEnvCmd) resolvePrompt() (inputDeleteEnv, error) {
+func (d *deleteEnvCmd) resolvePrompt() (string, error) {
 	envHolder, err := d.env.Find()
 	if err != nil {
-		return inputDeleteEnv{}, err
+		return "", err
 	}
 
 	if len(envHolder.All) <= 0 {
 		prompt.Error(NoDefinedEnvsMsg)
-		return inputDeleteEnv{}, nil
+		return "", nil
 	}
 
 	for i := range envHolder.All {
@@ -160,30 +160,30 @@ func (d *deleteEnvCmd) resolvePrompt() (inputDeleteEnv, error) {
 
 	envName, err := d.List("Envs:", envHolder.All)
 	if err != nil {
-		return inputDeleteEnv{}, err
+		return "", err
 	}
 
 	proceed, err := d.Bool("Are you sure want to delete this env?", []string{"yes", "no"})
 	if err != nil {
-		return inputDeleteEnv{}, err
+		return "", err
 	}
 
 	if !proceed {
-		return inputDeleteEnv{}, nil
+		return "", nil
 	}
 
-	return inputDeleteEnv{envName}, nil
+	return envName, nil
 }
 
-func (d *deleteEnvCmd) resolveFlags(cmd *cobra.Command) (inputDeleteEnv, error) {
+func (d *deleteEnvCmd) resolveFlags(cmd *cobra.Command) (string, error) {
 	env, err := cmd.Flags().GetString(envFlagName)
 	if err != nil {
-		return inputDeleteEnv{}, err
+		return "", err
 	}
 
 	if env == "" {
-		return inputDeleteEnv{}, errors.New("please provide a value for 'env'")
+		return "", errors.New("please provide a value for 'env'")
 	}
 
-	return inputDeleteEnv{env}, nil
+	return env, nil
 }

--- a/pkg/cmd/delete_env.go
+++ b/pkg/cmd/delete_env.go
@@ -48,10 +48,6 @@ var (
 	}
 )
 
-type teste struct {
-	env string
-}
-
 // deleteEnvCmd type for clean repo command.
 type deleteEnvCmd struct {
 	env env.FindRemover

--- a/pkg/cmd/delete_env.go
+++ b/pkg/cmd/delete_env.go
@@ -147,7 +147,7 @@ func (d *deleteEnvCmd) resolvePrompt() (string, error) {
 		return "", err
 	}
 
-	if len(envHolder.All) <= 0 {
+	if len(envHolder.All) == 0 {
 		prompt.Error(NoDefinedEnvsMsg)
 		return "", nil
 	}

--- a/pkg/cmd/delete_env.go
+++ b/pkg/cmd/delete_env.go
@@ -17,8 +17,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/ZupIT/ritchie-cli/pkg/env"
 
@@ -28,10 +30,27 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/stdin"
 )
 
+const (
+	envFlagName        = "env"
+	envFlagDescription = "Env name to delete"
+)
+
 var (
 	NoDefinedEnvsMsg    = "You have no defined envs"
 	DeleteEnvSuccessMsg = "Delete env successful!"
+	deleteEnvFlags      = flags{
+		{
+			name:        envFlagName,
+			kind:        reflect.String,
+			defValue:    "",
+			description: envFlagDescription,
+		},
+	}
 )
+
+type inputDeleteEnv struct {
+	env string
+}
 
 // deleteEnvCmd type for clean repo command.
 type deleteEnvCmd struct {
@@ -56,49 +75,30 @@ func NewDeleteEnvCmd(
 		Use:       "env",
 		Short:     "Delete env for credentials",
 		Example:   "rit delete env",
-		RunE:      RunFuncE(d.runStdin(), d.runPrompt()),
+		RunE:      RunFuncE(d.runStdin(), d.runFormula()),
 		ValidArgs: []string{""},
 		Args:      cobra.OnlyValidArgs,
 	}
+
+	addReservedFlags(cmd.Flags(), deleteEnvFlags)
 
 	cmd.LocalFlags()
 
 	return cmd
 }
 
-func (d deleteEnvCmd) runPrompt() CommandRunnerFunc {
+func (d *deleteEnvCmd) runFormula() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		envHolder, err := d.env.Find()
+		inputParams, err := d.resolveInput(cmd)
 		if err != nil {
 			return err
 		}
 
-		if len(envHolder.All) <= 0 {
-			prompt.Error(NoDefinedEnvsMsg)
+		if inputParams.env == "" {
 			return nil
 		}
 
-		for i := range envHolder.All {
-			if envHolder.All[i] == envHolder.Current {
-				envHolder.All[i] = fmt.Sprintf("%s%s", env.Current, envHolder.Current)
-			}
-		}
-
-		envName, err := d.List("Envs:", envHolder.All)
-		if err != nil {
-			return err
-		}
-
-		proceed, err := d.Bool("Are you sure want to delete this env?", []string{"yes", "no"})
-		if err != nil {
-			return err
-		}
-
-		if !proceed {
-			return nil
-		}
-
-		if _, err := d.env.Remove(envName); err != nil {
+		if _, err := d.env.Remove(inputParams.env); err != nil {
 			return err
 		}
 
@@ -107,6 +107,7 @@ func (d deleteEnvCmd) runPrompt() CommandRunnerFunc {
 	}
 }
 
+// TODO: remove upon stdin deprecation
 func (d deleteEnvCmd) runStdin() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		envHolder, err := d.env.Find()
@@ -131,4 +132,58 @@ func (d deleteEnvCmd) runStdin() CommandRunnerFunc {
 		prompt.Success(DeleteEnvSuccessMsg)
 		return nil
 	}
+}
+
+func (d *deleteEnvCmd) resolveInput(cmd *cobra.Command) (inputDeleteEnv, error) {
+	if IsFlagInput(cmd) {
+		return d.resolveFlags(cmd)
+	}
+	return d.resolvePrompt()
+}
+
+func (d *deleteEnvCmd) resolvePrompt() (inputDeleteEnv, error) {
+	envHolder, err := d.env.Find()
+	if err != nil {
+		return inputDeleteEnv{}, err
+	}
+
+	if len(envHolder.All) <= 0 {
+		prompt.Error(NoDefinedEnvsMsg)
+		return inputDeleteEnv{}, nil
+	}
+
+	for i := range envHolder.All {
+		if envHolder.All[i] == envHolder.Current {
+			envHolder.All[i] = fmt.Sprintf("%s%s", env.Current, envHolder.Current)
+		}
+	}
+
+	envName, err := d.List("Envs:", envHolder.All)
+	if err != nil {
+		return inputDeleteEnv{}, err
+	}
+
+	proceed, err := d.Bool("Are you sure want to delete this env?", []string{"yes", "no"})
+	if err != nil {
+		return inputDeleteEnv{}, err
+	}
+
+	if !proceed {
+		return inputDeleteEnv{}, nil
+	}
+
+	return inputDeleteEnv{envName}, nil
+}
+
+func (d *deleteEnvCmd) resolveFlags(cmd *cobra.Command) (inputDeleteEnv, error) {
+	env, err := cmd.Flags().GetString(envFlagName)
+	if err != nil {
+		return inputDeleteEnv{}, err
+	}
+
+	if env == "" {
+		return inputDeleteEnv{}, errors.New("please provide a value for 'env'")
+	}
+
+	return inputDeleteEnv{env}, nil
 }

--- a/pkg/env/finder_test.go
+++ b/pkg/env/finder_test.go
@@ -19,6 +19,7 @@ package env
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,9 @@ import (
 
 func TestFind(t *testing.T) {
 	tmp := os.TempDir()
+	ritHomeDir := filepath.Join(tmp, ".rit")
+	_ = os.MkdirAll(ritHomeDir, os.ModePerm)
+	defer os.RemoveAll(ritHomeDir)
 
 	type in struct {
 		holder          Holder
@@ -119,7 +123,7 @@ func TestFind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			finder := NewFinder(tmp, tt.in.FileReadExister)
+			finder := NewFinder(ritHomeDir, tt.in.FileReadExister)
 			out := tt.out
 			got, err := finder.Find()
 			if out.err != nil && out.err.Error() != err.Error() {

--- a/pkg/env/remover.go
+++ b/pkg/env/remover.go
@@ -18,6 +18,8 @@ package env
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -47,6 +49,19 @@ func (r RemoveManager) Remove(env string) (Holder, error) {
 	env = strings.ReplaceAll(env, Current, "")
 	if envHolder.Current == env {
 		envHolder.Current = ""
+	}
+
+	envExists := false
+	for i := range envHolder.All {
+		if envHolder.All[i] == env {
+			envExists = true
+			break
+		}
+	}
+
+	if !envExists {
+		errorString := fmt.Sprintf("env '%s' not found, please provide a value for env valid", env)
+		return Holder{}, errors.New(errorString)
 	}
 
 	for i, e := range envHolder.All {

--- a/pkg/env/remover_test.go
+++ b/pkg/env/remover_test.go
@@ -19,6 +19,7 @@ package env
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
@@ -28,9 +29,12 @@ import (
 
 func TestRemove(t *testing.T) {
 	tmp := os.TempDir()
+	ritHomeDir := filepath.Join(tmp, ".rit")
 	file := stream.NewFileManager()
-	finder := NewFinder(tmp, file)
-	setter := NewSetter(tmp, finder, file)
+	finder := NewFinder(ritHomeDir, file)
+	setter := NewSetter(ritHomeDir, finder, file)
+	_ = os.MkdirAll(ritHomeDir, os.ModePerm)
+	defer os.RemoveAll(ritHomeDir)
 
 	type in struct {
 		file      stream.FileWriter
@@ -122,7 +126,7 @@ func TestRemove(t *testing.T) {
 			in := tt.in
 			out := tt.out
 
-			remover := NewRemover(tmp, in.envFinder, in.file)
+			remover := NewRemover(ritHomeDir, in.envFinder, in.file)
 			got, err := remover.Remove(in.env)
 
 			if out.err != nil {

--- a/pkg/env/remover_test.go
+++ b/pkg/env/remover_test.go
@@ -36,7 +36,6 @@ func TestRemove(t *testing.T) {
 		file      stream.FileWriter
 		envFinder Finder
 		env       string
-		fileNil   bool
 	}
 
 	type out struct {

--- a/pkg/env/setter_test.go
+++ b/pkg/env/setter_test.go
@@ -19,6 +19,7 @@ package env
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -28,8 +29,11 @@ import (
 
 func TestSet(t *testing.T) {
 	tmp := os.TempDir()
+	ritHomeDir := filepath.Join(tmp, ".rit")
 	file := stream.NewFileManager()
-	finder := NewFinder(tmp, file)
+	finder := NewFinder(ritHomeDir, file)
+	_ = os.MkdirAll(ritHomeDir, os.ModePerm)
+	defer os.RemoveAll(ritHomeDir)
 
 	type in struct {
 		file      stream.FileWriter
@@ -128,7 +132,7 @@ func TestSet(t *testing.T) {
 			in := tt.in
 			out := tt.out
 
-			setter := NewSetter(tmp, in.envFinder, in.file)
+			setter := NewSetter(ritHomeDir, in.envFinder, in.file)
 			got, err := setter.Set(in.env)
 
 			if out.err != nil && out.err.Error() != err.Error() {


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
This PR deprecated stdin and add flags to `rit delete env`.

### How to verify it
Clone this PR, build the rit and use `rit delete env --env=prod`

> ![foto1](https://user-images.githubusercontent.com/67295691/104596103-4d5a4280-5652-11eb-954a-d7cad8a0e5f1.png)


### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Add suport to flag in rit delete env command