### PR TITLE
fix: required multiselect

### DIFF
--- a/pkg/formula/input/prompt/prompt_test.go
+++ b/pkg/formula/input/prompt/prompt_test.go
@@ -714,6 +714,27 @@ func TestInputManager_Multiselect(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "success multiselect input test when the required field is not sent",
+			in: in{
+				inputJSON: `[
+					{
+						"name": "sample_multiselect",
+						"type": "multiselect",
+						"items": [
+							"item_1",
+							"item_2",
+							"item_3",
+							"item_4"
+						],
+						"label": "Choose one or more items: ",
+						"tutorial": "Select one or more items for this field."
+					}
+				]`,
+				inMultiselect: inputMock{items: []string{"item_1", "item_2"}},
+			},
+			want: nil,
+		},
+		{
 			name: "fail multiselect input test",
 			in: in{
 				inputJSON: `[

--- a/pkg/prompt/multiselect.go
+++ b/pkg/prompt/multiselect.go
@@ -19,6 +19,7 @@ package prompt
 import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
+	fInput "github.com/ZupIT/ritchie-cli/pkg/formula/input"
 )
 
 type SurveyMultiselect struct{}
@@ -40,7 +41,7 @@ func (SurveyMultiselect) Multiselect(input formula.Input) ([]string, error) {
 		},
 	}
 
-	if *input.Required {
+	if fInput.IsRequired(input) {
 		multiQs[0].Validate = survey.Required
 	}
 

--- a/pkg/prompt/multiselect.go
+++ b/pkg/prompt/multiselect.go
@@ -19,7 +19,7 @@ package prompt
 import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
-	fInput "github.com/ZupIT/ritchie-cli/pkg/formula/input"
+	"github.com/ZupIT/ritchie-cli/pkg/formula/input"
 )
 
 type SurveyMultiselect struct{}
@@ -28,12 +28,12 @@ func NewSurveyMultiselect() SurveyMultiselect {
 	return SurveyMultiselect{}
 }
 
-func (SurveyMultiselect) Multiselect(input formula.Input) ([]string, error) {
+func (SurveyMultiselect) Multiselect(in formula.Input) ([]string, error) {
 	value := []string{}
 	multiselect := &survey.MultiSelect{
-		Message: input.Label,
-		Options: input.Items,
-		Help:    input.Tutorial,
+		Message: in.Label,
+		Options: in.Items,
+		Help:    in.Tutorial,
 	}
 	multiQs := []*survey.Question{
 		{
@@ -41,7 +41,7 @@ func (SurveyMultiselect) Multiselect(input formula.Input) ([]string, error) {
 		},
 	}
 
-	if fInput.IsRequired(input) {
+	if input.IsRequired(in) {
 		multiQs[0].Validate = survey.Required
 	}
 


### PR DESCRIPTION
### Description
The adoption team found a bug in the multiselect input when the required field is not sent.

To solve this, a validation was added that checks if the field is sent before being used in the code.

Close #839

### How to verify it
1. clone this PR (**`git fetch origin pull / 842 / head: fix/required-multiselect`**)
2. create a formula with **multiselect input** _without_ the **required field**
3. run the formula and verify that the error no longer occurs

### Changelog
Add validation in case the required field is not sent in the multiselect input
