### PR TITLE
Support for list input type

### DIFF
--- a/internal/mocks/credential.go
+++ b/internal/mocks/credential.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type CredResolverMock struct {
+	mock.Mock
+}
+
+func (i *CredResolverMock) Resolve(name string) (string, error) {
+	args := i.Called(name)
+	return args.String(0), args.Error(1)
+}

--- a/internal/mocks/error.go
+++ b/internal/mocks/error.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks
+
+import (
+	"fmt"
+)
+
+func FileNotFoundError(path string) string {
+	return fmt.Sprintf("open %s: no such file or directory", path)
+}

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -116,6 +116,26 @@ func (i *InputListMock) List(name string, items []string, helper ...string) (str
 	return args.String(0), args.Error(1)
 }
 
+type InputMultiselectMock struct {
+	mock.Mock
+}
+
+func (i *InputMultiselectMock) Multiselect(input formula.Input) ([]string, error) {
+	args := i.Called(input)
+
+	return args.Get(0).([]string), args.Error(1)
+}
+
+type InputDefaultTextMock struct {
+	mock.Mock
+}
+
+func (i *InputDefaultTextMock) Text(input formula.Input) (string, error) {
+	args := i.Called(input)
+
+	return args.String(0), args.Error(1)
+}
+
 type InputIntMock struct {
 	mock.Mock
 }
@@ -152,7 +172,7 @@ type InputTextValidatorMock struct {
 func (i *InputTextValidatorMock) Text(name string, validate func(interface{}) error, helper ...string) (string, error) {
 	args := i.Called(name, validate)
 
-	return args.String(0), args.Error(1)
+	return args.String(0), validate(args.String(0))
 }
 
 type FormCreator struct {

--- a/pkg/cmd/add_repo_test.go
+++ b/pkg/cmd/add_repo_test.go
@@ -177,9 +177,9 @@ func TestAddRepoCmd(t *testing.T) {
 			name: "input text error",
 			args: []string{},
 			fields: fields{
-				InputTextValidator: returnWithStringErr{"", ErrFormulaCmdNotBeEmpty},
+				InputTextValidator: returnWithStringErr{"", ErrRepoNameNotEmpty},
 			},
-			want: ErrFormulaCmdNotBeEmpty,
+			want: ErrRepoNameNotEmpty,
 		},
 		{
 			name: "input url error",
@@ -293,7 +293,7 @@ func TestAddRepoCmd(t *testing.T) {
 			inputPasswordMock := new(mocks.InputPasswordMock)
 			inputPasswordMock.On("Password", mock.Anything, mock.Anything).Return(fields.InputPassword.string, fields.InputPassword.error)
 			inputTextValidatorMock := new(mocks.InputTextValidatorMock)
-			inputTextValidatorMock.On("Text", mock.Anything, mock.Anything).Return(fields.InputTextValidator.string, fields.InputTextValidator.error)
+			inputTextValidatorMock.On("Text", mock.Anything, mock.Anything).Return(fields.InputTextValidator.string, nil)
 			tutorialFindMock := new(mocks.TutorialFindSetterMock)
 			tutorialFindMock.On("Find").Return(rtutorial.TutorialHolder{Current: fields.tutorialStatus.string}, fields.tutorialStatus.error)
 			repoListerAdderMock := new(mocks.RepoManager)

--- a/pkg/cmd/add_repo_test.go
+++ b/pkg/cmd/add_repo_test.go
@@ -177,9 +177,9 @@ func TestAddRepoCmd(t *testing.T) {
 			name: "input text error",
 			args: []string{},
 			fields: fields{
-				InputTextValidator: returnWithStringErr{"mocked text", someError},
+				InputTextValidator: returnWithStringErr{"", ErrFormulaCmdNotBeEmpty},
 			},
-			want: someError,
+			want: ErrFormulaCmdNotBeEmpty,
 		},
 		{
 			name: "input url error",

--- a/pkg/cmd/create_formula_test.go
+++ b/pkg/cmd/create_formula_test.go
@@ -76,7 +76,7 @@ func TestCreateFormulaCmd(t *testing.T) {
 			in: in{
 				inputTextValErr: errors.New("error on input text"),
 			},
-			want: errors.New("error on input text"),
+			want: ErrFormulaCmdNotBeEmpty,
 		},
 		{
 			name: "error on template manager Validate func",
@@ -187,6 +187,7 @@ func TestCreateFormulaCmd(t *testing.T) {
 				tutorialMock,
 				treeMock,
 			)
+			createFormulaCmd.SetArgs([]string{})
 			// TODO: remove it after being deprecated
 			createFormulaCmd.PersistentFlags().Bool("stdin", false, "input by stdin")
 			got := createFormulaCmd.Execute()

--- a/pkg/commands/builder.go
+++ b/pkg/commands/builder.go
@@ -144,7 +144,7 @@ func Build() *cobra.Command {
 
 	postRunner := runner.NewPostRunner(fileManager, dirManager)
 
-	promptInManager := fprompt.NewInputManager(credResolver, fileManager, inputList, inputText, inputTextValidator, inputTextDefault, inputBool, inputPassword, inputMultiselect)
+	promptInManager := fprompt.NewInputManager(credResolver, inputList, inputText, inputTextValidator, inputTextDefault, inputBool, inputPassword, inputMultiselect)
 	stdinInManager := stdin.NewInputManager(credResolver)
 	flagInManager := flag.NewInputManager(credResolver)
 	termInputTypes := formula.TermInputTypes{

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -14,6 +14,7 @@ type InputTextDefault interface {
 
 const (
 	TextType    = "text"
+	ListType    = "list"
 	BoolType    = "bool"
 	PassType    = "password"
 	DynamicType = "dynamic"

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -135,6 +135,11 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 			return in.loadInputValList(items, i)
 		}
 		return in.textValidator(i)
+	case input.ListType:
+		if items == nil || len(items) == 0 {
+			return "", fmt.Errorf(EmptyItems, i.Name)
+		}
+		return in.loadInputValList(items, i)
 	case input.DynamicType:
 		dl, err := in.dynamicList(i.RequestInfo)
 		if err != nil {
@@ -142,7 +147,7 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 		}
 		return in.List(i.Label, dl, i.Tutorial)
 	case input.Multiselect:
-		if len(items) == 0 {
+		if items == nil || len(items) == 0 {
 			return "", fmt.Errorf(EmptyItems, i.Name)
 		}
 		sl, err := in.Multiselect(i)

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -197,7 +197,7 @@ func (in InputManager) persistCache(formulaPath, inputVal string, input formula.
 		}
 		itemsBytes, _ := json.Marshal(items)
 		if err := ioutil.WriteFile(cachePath, itemsBytes, os.ModePerm); err != nil {
-			fmt.Sprintln("Write cache error")
+			fmt.Println("Write cache error")
 		}
 	}
 }
@@ -220,28 +220,27 @@ func (in InputManager) loadInputValList(items []string, input formula.Input) (st
 }
 
 func (in InputManager) loadItems(input formula.Input, formulaPath string) ([]string, error) {
-	if input.Cache.Active {
-		cachePath := fmt.Sprintf(CachePattern, formulaPath, strings.ToUpper(input.Name))
-		fileBytes, err := ioutil.ReadFile(cachePath)
-		if err != nil {
-			itemsBytes, err := json.Marshal(input.Items)
-			if err != nil {
-				return nil, err
-			}
-			if err = ioutil.WriteFile(cachePath, itemsBytes, os.ModePerm); err != nil {
-				return nil, err
-			}
-			return input.Items, nil
-		}
-		var items []string
-		err = json.Unmarshal(fileBytes, &items)
+	if !input.Cache.Active {
+		return input.Items, nil
+	}
+	cachePath := fmt.Sprintf(CachePattern, formulaPath, strings.ToUpper(input.Name))
+	fileBytes, err := ioutil.ReadFile(cachePath)
+	if err != nil {
+		itemsBytes, err := json.Marshal(input.Items)
 		if err != nil {
 			return nil, err
 		}
-		return items, nil
-	} else {
+		if err = ioutil.WriteFile(cachePath, itemsBytes, os.ModePerm); err != nil {
+			return nil, err
+		}
 		return input.Items, nil
 	}
+	var items []string
+	err = json.Unmarshal(fileBytes, &items)
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func (in InputManager) textValidator(i formula.Input) (string, error) {

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -131,7 +131,7 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 		}
 		return in.textValidator(i)
 	case input.ListType:
-		if items == nil || len(items) == 0 {
+		if len(items) == 0 {
 			return "", fmt.Errorf(EmptyItems, i.Name)
 		}
 		return in.loadInputValList(items, i)
@@ -142,7 +142,7 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 		}
 		return in.List(i.Label, dl, i.Tutorial)
 	case input.Multiselect:
-		if items == nil || len(items) == 0 {
+		if len(items) == 0 {
 			return "", fmt.Errorf(EmptyItems, i.Name)
 		}
 		sl, err := in.Multiselect(i)

--- a/pkg/formula/input/prompt/prompt_test.go
+++ b/pkg/formula/input/prompt/prompt_test.go
@@ -23,18 +23,19 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
-	"github.com/ZupIT/ritchie-cli/pkg/api"
-	"github.com/ZupIT/ritchie-cli/pkg/credential"
+	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
 )
 
-func TestInputManager_Inputs(t *testing.T) {
+func TestInputManager(t *testing.T) {
 
 	inputJson := `[
     {
@@ -78,6 +79,18 @@ func TestInputManager_Inputs(t *testing.T) {
         "label": "Pick your : ",
 		"tutorial": "Select an item for this field."
     },
+	{
+        "name": "sample_list2",
+        "type": "list",
+        "default": "in1",
+        "items": [
+            "in_list1",
+            "in_list2",
+            "in_list3",
+            "in_listN"
+        ],
+        "label": "Pick your : "
+    },
     {
         "name": "sample_bool",
         "type": "bool",
@@ -103,160 +116,108 @@ func TestInputManager_Inputs(t *testing.T) {
 	var inputs []formula.Input
 	_ = json.Unmarshal([]byte(inputJson), &inputs)
 	_ = os.Setenv("SAMPLE_TEXT", "someValue")
-
-	setup := formula.Setup{
-		Config: formula.Config{
-			Inputs: inputs,
-		},
-		FormulaPath: os.TempDir(),
-	}
-	fileManager := stream.NewFileManager()
-
-	type in struct {
-		iText          inputMock
-		iTextValidator inputTextValidatorMock
-		iTextDefault   inputTextDefaultMock
-		iList          inputMock
-		iBool          inputMock
-		iPass          inputMock
-		inType         api.TermInputType
-		creResolver    credential.Resolver
-		file           stream.FileWriteReadExister
-	}
+	ritHome := filepath.Join(os.TempDir(), "inputs")
+	_ = os.Mkdir(ritHome, os.ModePerm)
+	defer os.RemoveAll(ritHome)
 
 	tests := []struct {
-		name          string
-		in            in
-		want          error
-		expectedError string
+		name            string
+		ritHome         string
+		cacheContents   string
+		credResolverErr error
+		inputBoolErr    error
+		inputPassErr    error
+		inputTextErr    error
+		inputListErr    error
+		expectedError   string
 	}{
 		{
-			name: "success prompt",
-			in: in{
-				iText:          inputMock{text: ""},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "Type new value?"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManager,
-			},
-			want:          nil,
-			expectedError: "",
+			name:    "success prompt",
+			ritHome: ritHome,
 		},
 		{
-			name: "error read file load items",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManagerMock{rErr: errors.New("error to read file"), exist: true},
-			},
-			want:          errors.New(""),
-			expectedError: "error to read file",
-		},
-		{
-			name: "error unmarshal load items",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManagerMock{rBytes: []byte("error"), exist: true},
-			},
-			want:          errors.New(""),
+			name:          "error unmarshal load items",
+			ritHome:       ritHome,
+			cacheContents: "error",
 			expectedError: "invalid character 'e' looking for beginning of value",
 		},
 		{
-			name: "cache file doesn't exist success",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManagerMock{exist: false},
-			},
-			want:          nil,
+			name:          "cache file doesn't exist success",
+			ritHome:       ritHome,
 			expectedError: "",
 		},
 		{
-			name: "cache file doesn't exist error file write",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManagerMock{wErr: errors.New("error to write file"), exist: false},
-			},
-			want:          errors.New(""),
-			expectedError: "error to write file",
-		},
-		{
-			name: "persist cache file write error",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test"},
-				file:           fileManagerMock{wErr: errors.New("error to write file"), rBytes: []byte(`["in_list1","in_list2"]`), exist: true},
-			},
-			want:          nil,
+			name:          "persist cache file write error",
+			ritHome:       ritHome,
 			expectedError: "",
 		},
 		{
-			name: "error env resolver prompt",
-			in: in{
-				iText:          inputMock{text: DefaultCacheNewLabel},
-				iTextValidator: inputTextValidatorMock{},
-				iTextDefault:   inputTextDefaultMock{"test", nil},
-				iList:          inputMock{text: "test"},
-				iBool:          inputMock{boolean: false},
-				iPass:          inputMock{text: "******"},
-				inType:         api.Prompt,
-				creResolver:    envResolverMock{in: "test", err: errors.New("credential not found")},
-				file:           fileManager,
-			},
-			want:          errors.New(""),
-			expectedError: "credential not found",
+			name:            "error env resolver prompt",
+			ritHome:         ritHome,
+			credResolverErr: errors.New("credential not found"),
+			expectedError:   "credential not found",
+		},
+		{
+			name:          "error input bool",
+			ritHome:       ritHome,
+			inputBoolErr:  errors.New("bool error"),
+			expectedError: "bool error",
+		},
+		{
+			name:          "error input pass",
+			ritHome:       ritHome,
+			inputPassErr:  errors.New("pass error"),
+			expectedError: "pass error",
+		},
+		{
+			name:          "error input text",
+			ritHome:       ritHome,
+			inputTextErr:  errors.New("text error"),
+			expectedError: "text error",
+		},
+		{
+			name:          "error input list",
+			ritHome:       ritHome,
+			inputListErr:  errors.New("list error"),
+			expectedError: "list error",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			iText := tt.in.iText
-			iTextValidator := tt.in.iTextValidator
-			iTextDefault := tt.in.iTextDefault
-			iList := tt.in.iList
-			iBool := tt.in.iBool
-			iPass := tt.in.iPass
-			iMultiselect := inputMock{}
+			cacheFile := fmt.Sprintf(CachePattern, tt.ritHome, strings.ToUpper("SAMPLE_TEXT"))
+			if tt.cacheContents == "" {
+				_ = os.Remove(cacheFile)
+			} else {
+				_ = ioutil.WriteFile(cacheFile, []byte(tt.cacheContents), os.ModePerm)
+			}
+
+			iText := &mocks.InputTextMock{}
+			iText.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("text value", nil)
+			iTextValidator := &mocks.InputTextValidatorMock{}
+			iTextValidator.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("validator value", nil)
+			iList := &mocks.InputListMock{}
+			iList.On("List", mock.Anything, mock.Anything, mock.Anything).Return("list value", tt.inputListErr)
+			iBool := &mocks.InputBoolMock{}
+			iBool.On("Bool", mock.Anything, mock.Anything, mock.Anything).Return(true, tt.inputBoolErr)
+			iPass := &mocks.InputPasswordMock{}
+			iPass.On("Password", mock.Anything, mock.Anything, mock.Anything).Return("pass value", tt.inputPassErr)
+			iMultiselect := &mocks.InputMultiselectMock{}
+			iMultiselect.On("Multiselect", mock.Anything).Return([]string{"multiselect value"}, nil)
+			iTextDefault := &mocks.InputDefaultTextMock{}
+			iTextDefault.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("default value", tt.inputTextErr)
+			credResover := &mocks.CredResolverMock{}
+			credResover.On("Resolve", mock.Anything).Return("resolver value", tt.credResolverErr)
+
+			setup := formula.Setup{
+				Config: formula.Config{
+					Inputs: inputs,
+				},
+				FormulaPath: ritHome,
+			}
 
 			inputManager := NewInputManager(
-				tt.in.creResolver,
-				tt.in.file,
+				credResover,
 				iList,
 				iText,
 				iTextValidator,
@@ -268,18 +229,27 @@ func TestInputManager_Inputs(t *testing.T) {
 			cmd := &exec.Cmd{}
 			got := inputManager.Inputs(cmd, setup, nil)
 
-			if tt.expectedError != "" {
+			if got != nil {
 				assert.EqualError(t, got, tt.expectedError)
-			}
-
-			if tt.want == nil {
-				assert.Equal(t, tt.want, got)
+			} else {
+				assert.Empty(t, tt.expectedError)
+				expected := []string{
+					"SAMPLE_TEXT=default value",
+					"SAMPLE_TEXT=default value",
+					"SAMPLE_TEXT_2=default value",
+					"SAMPLE_LIST=list value",
+					"SAMPLE_LIST2=list value",
+					"SAMPLE_BOOL=true",
+					"SAMPLE_PASSWORD=pass value",
+					"TEST_RESOLVER=resolver value",
+				}
+				assert.Equal(t, expected, cmd.Env)
 			}
 		})
 	}
 }
 
-func TestInputManager_ConditionalInputs(t *testing.T) {
+func TestConditionalInputs(t *testing.T) {
 
 	inputJson := `[
 	{
@@ -292,11 +262,6 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
             "in_list3",
             "in_listN"
         ],
- 		"cache": {
-            "active": true,
-            "qty": 3,
-            "newLabel": "Type new value?"
-        },
         "label": "Pick your : "
     },
  	{
@@ -311,8 +276,6 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 		}
     }
 ]`
-
-	fileManager := stream.NewFileManager()
 
 	type in struct {
 		variable string
@@ -402,24 +365,20 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 				FormulaPath: os.TempDir(),
 			}
 
-			iText := inputMock{text: DefaultCacheNewLabel}
-			iTextValidator := inputTextValidatorMock{}
-			iTextDefault := inputTextDefaultMock{}
-			iList := inputMock{text: "in_list1"}
-			iBool := inputMock{boolean: false}
-			iPass := inputMock{text: "******"}
-			iMultiselect := inputMock{}
+			iTextDefault := &mocks.InputDefaultTextMock{}
+			iTextDefault.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("default value", nil)
+			iList := &mocks.InputListMock{}
+			iList.On("List", mock.Anything, mock.Anything, mock.Anything).Return("list value", nil)
 
 			inputManager := NewInputManager(
-				envResolverMock{},
-				fileManager,
+				&mocks.CredResolverMock{},
 				iList,
-				iText,
-				iTextValidator,
+				&mocks.InputTextMock{},
+				&mocks.InputTextValidatorMock{},
 				iTextDefault,
-				iBool,
-				iPass,
-				iMultiselect,
+				&mocks.InputBoolMock{},
+				&mocks.InputPasswordMock{},
+				&mocks.InputMultiselectMock{},
 			)
 
 			cmd := &exec.Cmd{}
@@ -430,23 +389,16 @@ func TestInputManager_ConditionalInputs(t *testing.T) {
 	}
 }
 
-func TestInputManager_RegexType(t *testing.T) {
-	type in struct {
-		inputJson      string
-		inText         inputMock
-		iTextValidator inputTextValidatorMock
-		iTextDefault   inputTextDefaultMock
-	}
-
+func TestRegexType(t *testing.T) {
 	tests := []struct {
-		name string
-		in   in
-		want error
+		name      string
+		inputJson string
+		inText    string
+		want      error
 	}{
 		{
 			name: "Success regex test",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					    {
 					        "name": "sample_text",
 					        "type": "text",
@@ -457,15 +409,12 @@ func TestInputManager_RegexType(t *testing.T) {
 									}
 					    }
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
-			want: nil,
+			inText: "a",
+			want:   nil,
 		},
 		{
 			name: "Failed regex test",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					    {
 					        "name": "sample_text",
 					        "type": "text",
@@ -476,15 +425,12 @@ func TestInputManager_RegexType(t *testing.T) {
 									}
 					    }
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
-			want: errors.New("mismatch"),
+			inText: "a",
+			want:   errors.New("mismatch"),
 		},
 		{
 			name: "Success regex test",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					    {
 					        "name": "sample_text",
 					        "type": "text",
@@ -495,18 +441,15 @@ func TestInputManager_RegexType(t *testing.T) {
 									}
 					    }
 					]`,
-				inText:         inputMock{text: "abcc"},
-				iTextValidator: inputTextValidatorMock{str: "abcc"},
-			},
-			want: nil,
+			inText: "abcc",
+			want:   nil,
 		},
 	}
 
-	fileManager := stream.NewFileManager()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var inputs []formula.Input
-			_ = json.Unmarshal([]byte(tt.in.inputJson), &inputs)
+			_ = json.Unmarshal([]byte(tt.inputJson), &inputs)
 
 			setup := formula.Setup{
 				Config: formula.Config{
@@ -515,24 +458,20 @@ func TestInputManager_RegexType(t *testing.T) {
 				FormulaPath: os.TempDir(),
 			}
 
-			iText := tt.in.inText
-			iTextValidator := tt.in.iTextValidator
-			iTextDefault := tt.in.iTextDefault
-			iList := inputMock{text: "in_list1"}
-			iBool := inputMock{boolean: false}
-			iPass := inputMock{text: "******"}
-			iMultiselect := inputMock{}
+			iText := &mocks.InputTextMock{}
+			iText.On("Text", mock.Anything, mock.Anything, mock.Anything).Return(tt.inText, nil)
+			iTextValidator := &mocks.InputTextValidatorMock{}
+			iTextValidator.On("Text", mock.Anything, mock.Anything, mock.Anything).Return(tt.inText, nil)
 
 			inputManager := NewInputManager(
-				envResolverMock{},
-				fileManager,
-				iList,
+				&mocks.CredResolverMock{},
+				&mocks.InputListMock{},
 				iText,
 				iTextValidator,
-				iTextDefault,
-				iBool,
-				iPass,
-				iMultiselect,
+				&mocks.InputDefaultTextMock{},
+				&mocks.InputBoolMock{},
+				&mocks.InputPasswordMock{},
+				&mocks.InputMultiselectMock{},
 			)
 
 			cmd := &exec.Cmd{}
@@ -543,22 +482,15 @@ func TestInputManager_RegexType(t *testing.T) {
 	}
 }
 
-func TestInputManager_DynamicInputs(t *testing.T) {
-	type in struct {
-		inputJson      string
-		inText         inputMock
-		iTextValidator inputTextValidatorMock
-	}
-
+func TestDynamicInputs(t *testing.T) {
 	tests := []struct {
-		name string
-		in   in
-		want error
+		name      string
+		inputJson string
+		want      error
 	}{
 		{
 			name: "Success dynamic input test",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					     {
       						"label": "Choose your repository ",
       						"name": "repo_list",
@@ -569,15 +501,11 @@ func TestInputManager_DynamicInputs(t *testing.T) {
       					 	}
     					}
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
 			want: nil,
 		},
 		{
 			name: "fail dynamic input when http status is not ok",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					     {
       						"label": "Choose your repository ",
       						"name": "repo_list",
@@ -588,15 +516,11 @@ func TestInputManager_DynamicInputs(t *testing.T) {
       					 	}
     					}
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
 			want: errors.New("dynamic list request got http status 404 expecting some 2xx range"),
 		},
 		{
 			name: "fail dynamic input when jsonpath is wrong",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					     {
       						"label": "Choose your repository ",
       						"name": "repo_list",
@@ -607,15 +531,11 @@ func TestInputManager_DynamicInputs(t *testing.T) {
       					 	}
     					}
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
 			want: errors.New(`unexpected "[" while scanning JSON select expected Ident, "." or "*"`),
 		},
 		{
 			name: "fail dynamic input when config.json url is empty",
-			in: in{
-				inputJson: `[
+			inputJson: `[
 					     {
       						"label": "Choose your repository ",
       						"name": "repo_list",
@@ -626,18 +546,14 @@ func TestInputManager_DynamicInputs(t *testing.T) {
       					 	}
     					}
 					]`,
-				inText:         inputMock{text: "a"},
-				iTextValidator: inputTextValidatorMock{str: "a"},
-			},
 			want: errors.New(`unsupported protocol scheme ""`),
 		},
 	}
 
-	fileManager := stream.NewFileManager()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var inputs []formula.Input
-			_ = json.Unmarshal([]byte(tt.in.inputJson), &inputs)
+			_ = json.Unmarshal([]byte(tt.inputJson), &inputs)
 
 			setup := formula.Setup{
 				Config: formula.Config{
@@ -646,24 +562,22 @@ func TestInputManager_DynamicInputs(t *testing.T) {
 				FormulaPath: os.TempDir(),
 			}
 
-			iText := tt.in.inText
-			iTextValidator := tt.in.iTextValidator
-			iTextDefault := inputTextDefaultMock{}
-			iList := inputMock{text: "in_list1"}
-			iBool := inputMock{boolean: false}
-			iPass := inputMock{text: "******"}
-			iMultiselect := inputMock{}
+			iText := &mocks.InputTextMock{}
+			iText.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("a", nil)
+			iTextValidator := &mocks.InputTextValidatorMock{}
+			iTextValidator.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("a", nil)
+			iList := &mocks.InputListMock{}
+			iList.On("List", mock.Anything, mock.Anything, mock.Anything).Return("list value", nil)
 
 			inputManager := NewInputManager(
-				envResolverMock{},
-				fileManager,
+				&mocks.CredResolverMock{},
 				iList,
 				iText,
 				iTextValidator,
-				iTextDefault,
-				iBool,
-				iPass,
-				iMultiselect,
+				&mocks.InputDefaultTextMock{},
+				&mocks.InputBoolMock{},
+				&mocks.InputPasswordMock{},
+				&mocks.InputMultiselectMock{},
 			)
 
 			cmd := &exec.Cmd{}
@@ -671,30 +585,23 @@ func TestInputManager_DynamicInputs(t *testing.T) {
 
 			if tt.want != nil {
 				assert.NotNil(t, got)
-			}
-
-			if tt.want == nil {
+			} else {
 				assert.Equal(t, tt.want, got)
 			}
 		})
 	}
 }
 
-func TestInputManager_Multiselect(t *testing.T) {
-	type in struct {
-		inputJSON     string
-		inMultiselect inputMock
-	}
-
+func TestMultiselect(t *testing.T) {
 	tests := []struct {
-		name string
-		in   in
-		want error
+		name             string
+		inputJSON        string
+		multiselectValue []string
+		want             error
 	}{
 		{
 			name: "success multiselect input test",
-			in: in{
-				inputJSON: `[
+			inputJSON: `[
 					{
 						"name": "sample_multiselect",
 						"type": "multiselect",
@@ -709,14 +616,12 @@ func TestInputManager_Multiselect(t *testing.T) {
 						"tutorial": "Select one or more items for this field."
 					}
 				]`,
-				inMultiselect: inputMock{items: []string{"item_1", "item_2"}},
-			},
-			want: nil,
+			multiselectValue: []string{"item_1", "item_2"},
+			want:             nil,
 		},
 		{
 			name: "fail multiselect input test",
-			in: in{
-				inputJSON: `[
+			inputJSON: `[
 					{
 						"name": "sample_multiselect",
 						"type": "multiselect",
@@ -726,17 +631,15 @@ func TestInputManager_Multiselect(t *testing.T) {
 						"tutorial": "Select one or more items for this field."
 					}
 				]`,
-				inMultiselect: inputMock{items: []string{}},
-			},
-			want: fmt.Errorf(EmptyItems, "sample_multiselect"),
+			multiselectValue: []string{},
+			want:             fmt.Errorf(EmptyItems, "sample_multiselect"),
 		},
 	}
 
-	fileManager := stream.NewFileManager()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var inputs []formula.Input
-			_ = json.Unmarshal([]byte(tt.in.inputJSON), &inputs)
+			_ = json.Unmarshal([]byte(tt.inputJSON), &inputs)
 
 			setup := formula.Setup{
 				Config: formula.Config{
@@ -745,23 +648,17 @@ func TestInputManager_Multiselect(t *testing.T) {
 				FormulaPath: os.TempDir(),
 			}
 
-			iText := tt.in.inMultiselect
-			iTextValidator := inputTextValidatorMock{}
-			iTextDefault := inputTextDefaultMock{}
-			iList := inputMock{text: "in_list1"}
-			iBool := inputMock{boolean: false}
-			iPass := inputMock{text: "******"}
-			iMultiselect := inputMock{items: []string{}}
+			iMultiselect := &mocks.InputMultiselectMock{}
+			iMultiselect.On("Multiselect", mock.Anything).Return(tt.multiselectValue, nil)
 
 			inputManager := NewInputManager(
-				envResolverMock{},
-				fileManager,
-				iList,
-				iText,
-				iTextValidator,
-				iTextDefault,
-				iBool,
-				iPass,
+				&mocks.CredResolverMock{},
+				&mocks.InputListMock{},
+				&mocks.InputTextMock{},
+				&mocks.InputTextValidatorMock{},
+				&mocks.InputDefaultTextMock{},
+				&mocks.InputBoolMock{},
+				&mocks.InputPasswordMock{},
 				iMultiselect,
 			)
 
@@ -773,7 +670,7 @@ func TestInputManager_Multiselect(t *testing.T) {
 	}
 }
 
-func TestInputManager_DefaultFlag(t *testing.T) {
+func TestDefaultFlag(t *testing.T) {
 	inputJson := `[
 		{
 			"name": "sample_text",
@@ -791,151 +688,34 @@ func TestInputManager_DefaultFlag(t *testing.T) {
 		},
 		FormulaPath: os.TempDir(),
 	}
-	fileManager := stream.NewFileManager()
 
-	type in struct {
-		inType      api.TermInputType
-		creResolver credential.Resolver
-		file        stream.FileWriteReadExister
-	}
+	t.Run("success prompt", func(t *testing.T) {
+		inputManager := NewInputManager(
+			&mocks.CredResolverMock{},
+			&mocks.InputListMock{},
+			&mocks.InputTextMock{},
+			&mocks.InputTextValidatorMock{},
+			&mocks.InputDefaultTextMock{},
+			&mocks.InputBoolMock{},
+			&mocks.InputPasswordMock{},
+			&mocks.InputMultiselectMock{},
+		)
 
-	tests := []struct {
-		name string
-		in   in
-	}{
-		{
-			name: "success prompt",
-			in: in{
-				inType:      api.Prompt,
-				creResolver: envResolverMock{in: "test"},
-				file:        fileManager,
-			},
-		},
-	}
+		cmd := &exec.Cmd{}
+		flags := pflag.NewFlagSet("default", 0)
+		flags.Bool("default", true, "default")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			inputManager := NewInputManager(
-				tt.in.creResolver,
-				tt.in.file,
-				inputMock{},
-				inputMock{},
-				inputTextValidatorMock{},
-				inputTextDefaultMock{},
-				inputMock{},
-				inputMock{},
-				inputMock{},
-			)
+		rescueStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
 
-			cmd := &exec.Cmd{}
-			flags := pflag.NewFlagSet("default", 0)
-			flags.Bool("default", true, "default")
+		err := inputManager.Inputs(cmd, setup, flags)
 
-			rescueStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
+		_ = w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stdout = rescueStdout
 
-			err := inputManager.Inputs(cmd, setup, flags)
-
-			_ = w.Close()
-			out, _ := ioutil.ReadAll(r)
-			os.Stdout = rescueStdout
-
-			assert.Nil(t, err)
-			assert.Contains(t, string(out), "Added sample_text by default: test")
-		})
-	}
-}
-
-type inputTextValidatorMock struct {
-	str string
-}
-
-func (i inputTextValidatorMock) Text(name string, validate func(interface{}) error, helper ...string) (string, error) {
-	return i.str, validate(i.str)
-}
-
-type inputMock struct {
-	text    string
-	boolean bool
-	items   []string
-	err     error
-}
-
-func (i inputMock) List(string, []string, ...string) (string, error) {
-	return i.text, i.err
-}
-
-func (i inputMock) Text(string, bool, ...string) (string, error) {
-	return i.text, i.err
-}
-
-func (i inputMock) Bool(string, []string, ...string) (bool, error) {
-	return i.boolean, i.err
-}
-
-func (i inputMock) Password(string, ...string) (string, error) {
-	return i.text, i.err
-}
-
-func (i inputMock) Multiselect(formula.Input) ([]string, error) {
-	return i.items, i.err
-}
-
-type inputTextDefaultMock struct {
-	text string
-	err  error
-}
-
-func (i inputTextDefaultMock) Text(formula.Input) (string, error) {
-	return i.text, i.err
-}
-
-type envResolverMock struct {
-	in  string
-	err error
-}
-
-func (e envResolverMock) Resolve(string) (string, error) {
-	return e.in, e.err
-}
-
-type fileManagerMock struct {
-	rBytes   []byte
-	rErr     error
-	wErr     error
-	aErr     error
-	mErr     error
-	rmErr    error
-	lErr     error
-	exist    bool
-	listNews []string
-}
-
-func (fi fileManagerMock) Write(string, []byte) error {
-	return fi.wErr
-}
-
-func (fi fileManagerMock) Read(string) ([]byte, error) {
-	return fi.rBytes, fi.rErr
-}
-
-func (fi fileManagerMock) Exists(string) bool {
-	return fi.exist
-}
-
-func (fi fileManagerMock) Append(path string, content []byte) error {
-	return fi.aErr
-}
-
-func (fi fileManagerMock) Move(oldPath, newPath string, files []string) error {
-	return fi.mErr
-}
-
-func (fi fileManagerMock) Remove(path string) error {
-	return fi.rmErr
-}
-
-func (fi fileManagerMock) ListNews(oldPath, newPath string) ([]string, error) {
-	return fi.listNews, fi.lErr
+		assert.Nil(t, err)
+		assert.Contains(t, string(out), "Added sample_text by default: test")
+	})
 }

--- a/pkg/formula/input/prompt/prompt_test.go
+++ b/pkg/formula/input/prompt/prompt_test.go
@@ -147,11 +147,7 @@ func TestInputManager(t *testing.T) {
 			ritHome: ritHome,
 		},
 		{
-			name:    "persist cache file write error",
-			ritHome: ritHome,
-		},
-		{
-			name:          "fail cache path",
+			name:          "persist cache file write error",
 			ritHome:       ritInvalidHome,
 			expectedError: mocks.FileNotFoundError(fmt.Sprintf(CachePattern, ritInvalidHome, strings.ToUpper("SAMPLE_TEXT"))),
 		},

--- a/pkg/formula/input/prompt/prompt_test.go
+++ b/pkg/formula/input/prompt/prompt_test.go
@@ -754,6 +754,6 @@ func TestEmptyList(t *testing.T) {
 		cmd := &exec.Cmd{}
 		got := inputManager.Inputs(cmd, setup, nil)
 
-		assert.Equal(t, fmt.Errorf(EmptyItems, "SAMPLE_LIST"), got)
+		assert.Equal(t, fmt.Errorf(EmptyItems, "sample_list"), got)
 	})
 }

--- a/pkg/formula/runner/docker/runner_test.go
+++ b/pkg/formula/runner/docker/runner_test.go
@@ -53,7 +53,7 @@ func TestRun(t *testing.T) {
 	envFinder := env.NewFinder(ritHome, fileManager)
 	preRunner := NewPreRun(ritHome, dockerBuilder, dirManager, fileManager)
 	postRunner := runner.NewPostRunner(fileManager, dirManager)
-	pInputRunner := prompt.NewInputManager(envResolverMock{in: "test"}, fileManager, inputMock{}, inputMock{}, inputTextValidatorMock{str: "test"}, inputTextDefaultMock{}, inputMock{}, inputMock{}, inputMock{})
+	pInputRunner := prompt.NewInputManager(envResolverMock{in: "test"}, inputMock{}, inputMock{}, inputTextValidatorMock{str: "test"}, inputTextDefaultMock{}, inputMock{}, inputMock{}, inputMock{})
 	sInputRunner := stdin.NewInputManager(envResolverMock{in: "test"})
 	fInputRunner := flag.NewInputManager(envResolverMock{in: "test"})
 

--- a/pkg/formula/runner/local/runner_test.go
+++ b/pkg/formula/runner/local/runner_test.go
@@ -55,7 +55,7 @@ func TestRun(t *testing.T) {
 	envFinder := env.NewFinder(ritHome, fileManager)
 	preRunner := NewPreRun(ritHome, makeBuilder, batBuilder, shellBuilder, dirManager, fileManager)
 	postRunner := runner.NewPostRunner(fileManager, dirManager)
-	pInputRunner := prompt.NewInputManager(envResolverMock{in: "test"}, fileManager, inputMock{}, inputMock{}, inputTextValidatorMock{}, inputTextDefaultMock{}, inputMock{}, inputMock{}, inputMock{})
+	pInputRunner := prompt.NewInputManager(envResolverMock{in: "test"}, inputMock{}, inputMock{}, inputTextValidatorMock{}, inputTextDefaultMock{}, inputMock{}, inputMock{}, inputMock{})
 	sInputRunner := stdin.NewInputManager(envResolverMock{in: "test"})
 	fInputRunner := flag.NewInputManager(envResolverMock{in: "test"})
 

--- a/pkg/formula/workspace/workspace_test.go
+++ b/pkg/formula/workspace/workspace_test.go
@@ -96,10 +96,7 @@ func TestWorkspaceManagerAdd(t *testing.T) {
 				Name: "commons",
 				Dir:  fullDir,
 			},
-			outErr: fmt.Sprintf(
-				"open %s: no such file or directory",
-				filepath.Join(workspaceNonExistingPath, formula.WorkspacesFile),
-			),
+			outErr: mocks.FileNotFoundError(filepath.Join(workspaceNonExistingPath, formula.WorkspacesFile)),
 		},
 	}
 
@@ -170,10 +167,7 @@ func TestManagerDelete(t *testing.T) {
 				Name: "Default",
 				Dir:  fullDir,
 			},
-			outErr: fmt.Sprintf(
-				"open %s: no such file or directory",
-				filepath.Join(fileNonExistentPath, formula.WorkspacesFile),
-			),
+			outErr: mocks.FileNotFoundError(filepath.Join(fileNonExistentPath, formula.WorkspacesFile)),
 		},
 	}
 
@@ -286,10 +280,7 @@ func TestPreviousHash(t *testing.T) {
 		{
 			name:     "shoud fail when file doesn't exist",
 			homePath: formulaNonExistentPath,
-			outErr: fmt.Sprintf(
-				"open %s: no such file or directory",
-				path.Join(formulaNonExistentPath, "hashes", "my-formula.txt"),
-			),
+			outErr:   mocks.FileNotFoundError(path.Join(formulaNonExistentPath, "hashes", "my-formula.txt")),
 		},
 	}
 

--- a/pkg/formula/workspace/workspace_test.go
+++ b/pkg/formula/workspace/workspace_test.go
@@ -18,7 +18,6 @@ package workspace
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
An excuse to refactor `package prompt` tests. Some of the implementations in this PR
* Support for `list` type in the `config.json` file
* Removed mocks from the test file
* Test refactor of the 900+ lines of code to comply with the new implementation method (closes #783 )
* Removed `fileManager` dependency from `prompt`
* Tests actually check if envs were created
* Removed non dynamic entries from table tests
* Removed table test from `Default` test, since it only had a single test

### How to verify it
Run a formula with the config `"type": "list"`, it should work normally

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Support for list input type
