### PR TITLE
Tutorial flags

### DIFF
--- a/pkg/cmd/create_formula_test.go
+++ b/pkg/cmd/create_formula_test.go
@@ -407,7 +407,7 @@ func createFormulaCmdDeps(ritchieHomeDir string, dirManager stream.DirManager, f
 	createBuilder := formula.NewCreateBuilder(createManager, formBuildLocal)
 	buildLocal := builder.NewBuildLocal(ritchieHomeDir, dirManager, repoAdder)
 	wspaceManager := workspace.New(ritchieHomeDir, os.TempDir(), dirManager, buildLocal)
-	tutorialFinder := rtutorial.NewFinder(ritchieHomeDir, fileManager)
+	tutorialFinder := rtutorial.NewFinder(ritchieHomeDir)
 
 	return createFormulaCmd{
 		formula:   createBuilder,

--- a/pkg/cmd/tutorial.go
+++ b/pkg/cmd/tutorial.go
@@ -29,7 +29,6 @@ import (
 )
 
 type tutorialCmd struct {
-	homePath string
 	prompt.InputList
 	tutorial rtutorial.FindSetter
 }
@@ -50,8 +49,8 @@ var tutorialFlags = flags{
 }
 
 // NewTutorialCmd creates tutorial command.
-func NewTutorialCmd(homePath string, il prompt.InputList, fs rtutorial.FindSetter) *cobra.Command {
-	o := tutorialCmd{homePath, il, fs}
+func NewTutorialCmd(il prompt.InputList, tt rtutorial.FindSetter) *cobra.Command {
+	o := tutorialCmd{il, tt}
 
 	cmd := &cobra.Command{
 		Use:       "tutorial",

--- a/pkg/cmd/tutorial.go
+++ b/pkg/cmd/tutorial.go
@@ -95,9 +95,8 @@ func (t *tutorialCmd) resolveFlags(cmd *cobra.Command) (string, error) {
 		return "", errors.New(missingFlagText(enabledFlagName))
 	} else if enabled {
 		return tutorialStatusEnabled, nil
-	} else {
-		return tutorialStatusDisabled, nil
 	}
+	return tutorialStatusDisabled, nil
 }
 
 func (t *tutorialCmd) resolvePrompt() (string, error) {

--- a/pkg/cmd/tutorial_test.go
+++ b/pkg/cmd/tutorial_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,7 +91,7 @@ func TestTutorialCmd(t *testing.T) {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.Nil(t, tt.err)
-				assert.FileExists(t, fmt.Sprintf(rtutorial.TutorialPath, tt.ritHome))
+				assert.FileExists(t, filepath.Join(tt.ritHome, rtutorial.TutorialFile))
 			}
 		})
 	}

--- a/pkg/cmd/tutorial_test.go
+++ b/pkg/cmd/tutorial_test.go
@@ -18,29 +18,90 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/ZupIT/ritchie-cli/pkg/prompt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
 )
 
-func TestNewTutorialCmd(t *testing.T) {
-	cmd := NewTutorialCmd("path/any", inputListMock{}, TutorialFindSetterMock{})
-	cmd.PersistentFlags().Bool("stdin", false, "input by stdin")
+func TestTutorialCmd(t *testing.T) {
+	ritPath := filepath.Join(os.TempDir(), "tutorial")
+	_ = os.Mkdir(ritPath, os.ModePerm)
+	defer os.RemoveAll(ritPath)
 
-	if cmd == nil {
-		t.Errorf("NewTutorialCmd got %v", cmd)
+	tutorialFinder := rtutorial.NewFinder(ritPath)
+	tutorialSetter := rtutorial.NewSetter(ritPath)
+	tutorialFindSetter := rtutorial.NewFindSetter(tutorialFinder, tutorialSetter)
+
+	tests := []struct {
+		name    string
+		ritHome string
+		args    []string
+		listErr error
+		err     error
+	}{
+		{
+			name:    "success prompt",
+			ritHome: ritPath,
+			args:    []string{},
+		},
+		{
+			name:    "fail list",
+			ritHome: ritPath,
+			args:    []string{},
+			listErr: errors.New("list error"),
+			err:     errors.New("list error"),
+		},
+		{
+			name:    "success flags",
+			ritHome: ritPath,
+			args:    []string{"--enabled=true"},
+		},
+		{
+			name:    "fail empty flag",
+			ritHome: ritPath,
+			args:    []string{"--enabled="},
+			err:     errors.New("invalid argument \"\" for \"--enabled\" flag: strconv.ParseBool: parsing \"\": invalid syntax"),
+		},
+		{
+			name:    "fail set",
+			ritHome: ritPath,
+			args:    []string{},
+		},
 	}
 
-	if err := cmd.Execute(); err != nil {
-		t.Errorf("%s = %v, want %v", cmd.Use, err, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputList := &mocks.InputListMock{}
+			inputList.On("List", mock.Anything, mock.Anything, mock.Anything).Return(tutorialStatusEnabled, tt.listErr)
+			cmd := NewTutorialCmd(inputList, tutorialFindSetter)
+
+			cmd.PersistentFlags().Bool("stdin", false, "input by stdin")
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			if err != nil {
+				assert.Equal(t, tt.err, err)
+			} else {
+				assert.Nil(t, tt.err)
+				assert.FileExists(t, fmt.Sprintf(rtutorial.TutorialPath, tt.ritHome))
+			}
+		})
 	}
 }
 
 func TestNewTutorialStdin(t *testing.T) {
-	cmd := NewTutorialCmd("path/any", inputListMock{}, TutorialFindSetterMock{})
+	cmd := NewTutorialCmd(inputListMock{}, TutorialFindSetterMock{})
 	cmd.PersistentFlags().Bool("stdin", true, "input by stdin")
+	cmd.SetArgs([]string{})
 
 	input := "{\"tutorial\": \"enabled\"}\n"
 	newReader := strings.NewReader(input)
@@ -55,141 +116,11 @@ func TestNewTutorialStdin(t *testing.T) {
 	}
 }
 
-func TestTutorialRunAnyEntry(t *testing.T) {
-	var tutorialHolderEnabled, tutorialHolderDisabled rtutorial.TutorialHolder
-	type fields struct {
-		prompt.InputList
-		tutorial rtutorial.FindSetter
-	}
-
-	tutorialHolderEnabled.Current = "enabled"
-	tutorialHolderDisabled.Current = "disabled"
-
-	tests := []struct {
-		name       string
-		fields     fields
-		wantErr    bool
-		inputStdin string
-	}{
-		{
-			name: "Run With Success when set tutorial enabled",
-			fields: fields{
-				InputList: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "enabled", nil
-					},
-				},
-				tutorial: TutorialFindSetterMock{},
-			},
-			wantErr:    false,
-			inputStdin: "{\"tutorial\": \"enabled\"}\n",
-		},
-		{
-			name: "Run With Success when set tutorial disabled",
-			fields: fields{
-				InputList: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "disabled", nil
-					},
-				},
-				tutorial: TutorialFindSetterMock{},
-			},
-			wantErr:    false,
-			inputStdin: "{\"tutorial\": \"disabled\"}\n",
-		},
-		{
-			name: "Return error when set return error",
-			fields: fields{
-				InputList: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "enabled", nil
-					},
-				},
-				tutorial: TutorialFindSetterCustomMock{
-					set: func(tutorial string) (rtutorial.TutorialHolder, error) {
-						return tutorialHolderEnabled, errors.New("some error")
-					},
-					find: func() (rtutorial.TutorialHolder, error) {
-						return tutorialHolderEnabled, nil
-					},
-				},
-			},
-			wantErr:    true,
-			inputStdin: "{\"tutorial\": \"enabled\"}\n",
-		},
-	}
-	for _, tt := range tests {
-		cmdPrompt := NewTutorialCmd("path/any", tt.fields.InputList, tt.fields.tutorial)
-		cmdStdin := NewTutorialCmd("path/any", tt.fields.InputList, tt.fields.tutorial)
-
-		cmdPrompt.PersistentFlags().Bool("stdin", false, "input by stdin")
-		cmdStdin.PersistentFlags().Bool("stdin", true, "input by stdin")
-
-		newReader := strings.NewReader(tt.inputStdin)
-		cmdStdin.SetIn(newReader)
-
-		if err := cmdPrompt.Execute(); (err != nil) != tt.wantErr {
-			t.Errorf("cmd_runPrompt() error = %v, wantErr %v", err, tt.wantErr)
-		}
-		if err := cmdStdin.Execute(); (err != nil) != tt.wantErr {
-			t.Errorf("cmd_runStdin() error = %v, wantErr %v", err, tt.wantErr)
-		}
-	}
-}
-
-func TestTutorialRunOnlyPrompt(t *testing.T) {
-	type fields struct {
-		prompt.InputList
-		tutorial rtutorial.FindSetter
-	}
-
-	var tutorialHolderEnabled rtutorial.TutorialHolder
-	tutorialHolderEnabled.Current = "enabled"
-
-	tests := []struct {
-		name   string
-		fields fields
-	}{
-		{
-			name: "Return error when find return error",
-			fields: fields{
-				InputList: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "enabled", nil
-					},
-				},
-				tutorial: TutorialFindSetterCustomMock{
-					find: func() (rtutorial.TutorialHolder, error) {
-						return tutorialHolderEnabled, errors.New("some error")
-					},
-				},
-			},
-		},
-		{
-			name: "Return error when list return error",
-			fields: fields{
-				InputList: inputListErrorMock{},
-				tutorial:  TutorialFindSetterMock{},
-			},
-		},
-	}
-	for _, tt := range tests {
-		wantErr := true
-
-		cmd := NewTutorialCmd("path/any", tt.fields.InputList, tt.fields.tutorial)
-		cmd.PersistentFlags().Bool("stdin", false, "input by stdin")
-
-		if err := cmd.Execute(); (err != nil) != wantErr {
-			t.Errorf("cmd_runPrompt() error = %v, wantErr %v", err, wantErr)
-		}
-	}
-}
-
 func TestTutorialRunOnlyStdin(t *testing.T) {
 	t.Run("Error when readJson returns err", func(t *testing.T) {
 		wantErr := true
 
-		cmdStdin := NewTutorialCmd("path/any", inputListMock{}, TutorialFindSetterMock{})
+		cmdStdin := NewTutorialCmd(inputListMock{}, TutorialFindSetterMock{})
 		cmdStdin.PersistentFlags().Bool("stdin", true, "input by stdin")
 
 		newReader := strings.NewReader("{\"tutorial\": 1}\n")

--- a/pkg/commands/builder.go
+++ b/pkg/commands/builder.go
@@ -132,9 +132,9 @@ func Build() *cobra.Command {
 	treeChecker := tree.NewChecker(treeManager)
 	autocompleteGen := autocomplete.NewGenerator(treeManager)
 	credResolver := credential.NewResolver(credFinder, credSetter, inputPassword)
-	tutorialFinder := rtutorial.NewFinder(ritchieHomeDir, fileManager)
-	tutorialSetter := rtutorial.NewSetter(ritchieHomeDir, fileManager)
-	tutorialFindSetter := rtutorial.NewFindSetter(ritchieHomeDir, tutorialFinder, tutorialSetter)
+	tutorialFinder := rtutorial.NewFinder(ritchieHomeDir)
+	tutorialSetter := rtutorial.NewSetter(ritchieHomeDir)
+	tutorialFindSetter := rtutorial.NewFindSetter(tutorialFinder, tutorialSetter)
 
 	formBuildMake := builder.NewBuildMake()
 	formBuildSh := builder.NewBuildShell()
@@ -204,7 +204,7 @@ func Build() *cobra.Command {
 		githubRepo,
 	)
 	metricsCmd := cmd.NewMetricsCmd(fileManager, inputList)
-	tutorialCmd := cmd.NewTutorialCmd(ritchieHomeDir, inputList, tutorialFindSetter)
+	tutorialCmd := cmd.NewTutorialCmd(inputList, tutorialFindSetter)
 
 	// level 2
 	setCredentialCmd := cmd.NewSetCredentialCmd(

--- a/pkg/rtutorial/find_setter.go
+++ b/pkg/rtutorial/find_setter.go
@@ -16,14 +16,11 @@
 
 package rtutorial
 
-import "fmt"
-
 type FindSetterManager struct {
-	tutorialFile string
 	Finder
 	Setter
 }
 
-func NewFindSetter(homePath string, f Finder, s Setter) FindSetterManager {
-	return FindSetterManager{fmt.Sprintf(TutorialPath, homePath), f, s}
+func NewFindSetter(f Finder, s Setter) FindSetterManager {
+	return FindSetterManager{f, s}
 }

--- a/pkg/rtutorial/finder.go
+++ b/pkg/rtutorial/finder.go
@@ -19,32 +19,28 @@ package rtutorial
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
+	"io/ioutil"
+	"os"
 )
 
 type FindManager struct {
 	tutorialFile string
-	homePath     string
-	fr           stream.FileReadExister
 }
 
-func NewFinder(homePath string, fr stream.FileReadExister) FindManager {
+func NewFinder(homePath string) FindManager {
 	return FindManager{
 		tutorialFile: fmt.Sprintf(TutorialPath, homePath),
-		homePath:     homePath,
-		fr:           fr,
 	}
 }
 
 func (f FindManager) Find() (TutorialHolder, error) {
 	tutorialHolder := TutorialHolder{Current: DefaultTutorial}
 
-	if !f.fr.Exists(f.tutorialFile) {
+	if _, err := os.Stat(f.tutorialFile); os.IsNotExist(err) {
 		return tutorialHolder, nil
 	}
 
-	file, err := f.fr.Read(f.tutorialFile)
+	file, err := ioutil.ReadFile(f.tutorialFile)
 	if err != nil {
 		return tutorialHolder, err
 	}

--- a/pkg/rtutorial/finder.go
+++ b/pkg/rtutorial/finder.go
@@ -18,9 +18,9 @@ package rtutorial
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 type FindManager struct {
@@ -29,7 +29,7 @@ type FindManager struct {
 
 func NewFinder(homePath string) FindManager {
 	return FindManager{
-		tutorialFile: fmt.Sprintf(TutorialPath, homePath),
+		tutorialFile: filepath.Join(homePath, TutorialFile),
 	}
 }
 

--- a/pkg/rtutorial/finder_test.go
+++ b/pkg/rtutorial/finder_test.go
@@ -17,92 +17,58 @@
 package rtutorial
 
 import (
-	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"reflect"
+	"path/filepath"
 	"testing"
 
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
-	sMocks "github.com/ZupIT/ritchie-cli/pkg/stream/mocks"
+	"github.com/stretchr/testify/assert"
 )
 
-var errReadingFile = errors.New("error reading file")
-
 func TestFind(t *testing.T) {
-	type out struct {
-		err       error
-		want      TutorialHolder
-		wantError bool
-	}
+	ritHome := filepath.Join(os.TempDir(), "tutorial")
+	_ = os.Mkdir(ritHome, os.ModePerm)
+	defer os.RemoveAll(ritHome)
 
 	tests := []struct {
-		name string
-		in   stream.FileReadExister
-		out  *out
+		name        string
+		holderState string
+		fileContent string
+		err         string
 	}{
 		{
-			name: "With no tutorial file",
-			in: sMocks.FileReadExisterCustomMock{
-				ExistsMock: func(path string) bool {
-					return false
-				},
-			},
-			out: &out{
-				want:      TutorialHolder{Current: "enabled"},
-				err:       nil,
-				wantError: false,
-			},
+			name:        "With no tutorial file",
+			holderState: "enabled",
 		},
 		{
-			name: "With existing tutorial file",
-			in: sMocks.FileReadExisterCustomMock{
-				ReadMock: func(path string) ([]byte, error) {
-					return []byte("{\"tutorial\":\"disabled\"}"), nil
-				},
-				ExistsMock: func(path string) bool {
-					return true
-				},
-			},
-			out: &out{
-				want:      TutorialHolder{Current: "disabled"},
-				err:       nil,
-				wantError: false,
-			},
+			name:        "With existing tutorial file",
+			holderState: "disabled",
+			fileContent: `{"tutorial": "disabled"}`,
 		},
 		{
-			name: "Error reading the tutorial file",
-			in: sMocks.FileReadExisterCustomMock{
-				ReadMock: func(path string) ([]byte, error) {
-					return []byte(""), errReadingFile
-				},
-				ExistsMock: func(path string) bool {
-					return true
-				},
-			},
-			out: &out{
-				want:      TutorialHolder{Current: "enabled"},
-				err:       errReadingFile,
-				wantError: true,
-			},
+			name:        "Error reading the tutorial file",
+			fileContent: "error",
+			err:         "invalid character 'e' looking for beginning of value",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp := os.TempDir()
-			tmpTutorial := fmt.Sprintf(TutorialPath, tmp)
-			defer os.RemoveAll(tmpTutorial)
-
-			finder := NewFinder(tmp, tt.in)
-
-			out := tt.out
-			got, err := finder.Find()
-			if err != nil && !tt.out.wantError {
-				t.Errorf("%s - Execution error - got %v, want %v", tt.name, err, out.err)
+			if tt.fileContent != "" {
+				err := ioutil.WriteFile(fmt.Sprintf(TutorialPath, ritHome), []byte(tt.fileContent), os.ModePerm)
+				assert.NoError(t, err)
 			}
-			if !reflect.DeepEqual(out.want, got) {
-				t.Errorf("%s - Error in the expected response -  got %v, want %v", tt.name, got, out.want)
+
+			finder := NewFinder(ritHome)
+
+			got, err := finder.Find()
+
+			if err != nil {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.Empty(t, tt.err)
+				assert.Equal(t, tt.holderState, got.Current)
 			}
 		})
 	}

--- a/pkg/rtutorial/finder_test.go
+++ b/pkg/rtutorial/finder_test.go
@@ -17,7 +17,6 @@
 package rtutorial
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ func TestFind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.fileContent != "" {
-				err := ioutil.WriteFile(fmt.Sprintf(TutorialPath, ritHome), []byte(tt.fileContent), os.ModePerm)
+				err := ioutil.WriteFile(filepath.Join(ritHome, TutorialFile), []byte(tt.fileContent), os.ModePerm)
 				assert.NoError(t, err)
 			}
 

--- a/pkg/rtutorial/setter.go
+++ b/pkg/rtutorial/setter.go
@@ -19,35 +19,32 @@ package rtutorial
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
+	"io/ioutil"
+	"os"
 )
 
 type SetterManager struct {
 	tutorialFile string
-	fw           stream.FileWriter
 }
 
-func NewSetter(homePath string, fw stream.FileWriter) Setter {
+func NewSetter(homePath string) Setter {
 	return SetterManager{
 		tutorialFile: fmt.Sprintf(TutorialPath, homePath),
-		fw:           fw,
 	}
 }
 
 func (s SetterManager) Set(tutorial string) (TutorialHolder, error) {
 	tutorialHolder := TutorialHolder{Current: DefaultTutorial}
-	tutorialHolderDefault := TutorialHolder{Current: DefaultTutorial}
 
 	tutorialHolder.Current = tutorial
 
 	b, err := json.Marshal(&tutorialHolder)
 	if err != nil {
-		return tutorialHolderDefault, err
+		return tutorialHolder, err
 	}
 
-	if err := s.fw.Write(s.tutorialFile, b); err != nil {
-		return tutorialHolderDefault, err
+	if err := ioutil.WriteFile(s.tutorialFile, b, os.ModePerm); err != nil {
+		return tutorialHolder, err
 	}
 
 	return tutorialHolder, nil

--- a/pkg/rtutorial/setter.go
+++ b/pkg/rtutorial/setter.go
@@ -18,9 +18,9 @@ package rtutorial
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 type SetterManager struct {
@@ -29,7 +29,7 @@ type SetterManager struct {
 
 func NewSetter(homePath string) Setter {
 	return SetterManager{
-		tutorialFile: fmt.Sprintf(TutorialPath, homePath),
+		tutorialFile: filepath.Join(homePath, TutorialFile),
 	}
 }
 

--- a/pkg/rtutorial/setter_test.go
+++ b/pkg/rtutorial/setter_test.go
@@ -18,9 +18,9 @@ package rtutorial
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +45,7 @@ func TestSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmp := os.TempDir()
-			tmpTutorial := fmt.Sprintf(TutorialPath, tmp)
+			tmpTutorial := filepath.Join(tmp, TutorialFile)
 			defer os.Remove(tmpTutorial)
 
 			setter := NewSetter(tmp)

--- a/pkg/rtutorial/setter_test.go
+++ b/pkg/rtutorial/setter_test.go
@@ -17,71 +17,28 @@
 package rtutorial
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 
-	"github.com/ZupIT/ritchie-cli/pkg/stream"
-	sMocks "github.com/ZupIT/ritchie-cli/pkg/stream/mocks"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSet(t *testing.T) {
-	type out struct {
-		want      TutorialHolder
-		err       error
-		waitError bool
-	}
-	err := errors.New("some error")
 
 	tests := []struct {
-		name       string
-		in         string
-		out        *out
-		FileWriter stream.FileWriter
+		name string
+		in   string
 	}{
 		{
 			name: "Set enabled tutorial",
 			in:   "enabled",
-			out: &out{
-				want:      TutorialHolder{Current: "enabled"},
-				err:       nil,
-				waitError: false,
-			},
-			FileWriter: sMocks.FileWriterCustomMock{
-				WriteMock: func(path string, content []byte) error {
-					return nil
-				},
-			},
 		},
 		{
 			name: "Set disabled tutorial",
 			in:   "disabled",
-			out: &out{
-				want:      TutorialHolder{Current: "disabled"},
-				err:       nil,
-				waitError: false,
-			},
-			FileWriter: sMocks.FileWriterCustomMock{
-				WriteMock: func(path string, content []byte) error {
-					return nil
-				},
-			},
-		},
-		{
-			name: "Error writing the tutorial file",
-			in:   DefaultTutorial,
-			out: &out{
-				want:      TutorialHolder{Current: DefaultTutorial},
-				err:       err,
-				waitError: true,
-			},
-			FileWriter: sMocks.FileWriterCustomMock{
-				WriteMock: func(path string, content []byte) error {
-					return err
-				},
-			},
 		},
 	}
 
@@ -89,20 +46,22 @@ func TestSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmp := os.TempDir()
 			tmpTutorial := fmt.Sprintf(TutorialPath, tmp)
-			defer os.RemoveAll(tmpTutorial)
+			defer os.Remove(tmpTutorial)
 
-			setter := NewSetter(tmp, tt.FileWriter)
+			setter := NewSetter(tmp)
+			got, err := setter.Set(tt.in)
+			assert.NoError(t, err)
 
-			in := tt.in
-			out := tt.out
+			expected := TutorialHolder{Current: tt.in}
+			assert.Equal(t, expected, got)
 
-			got, err := setter.Set(in)
-			if err != nil && !tt.out.waitError {
-				t.Errorf("Set(%s) - Execution error - got %v, want %v", tt.name, err, out.err)
-			}
-			if !reflect.DeepEqual(out.want, got) {
-				t.Errorf("Set(%s) - Error in the expected response -  got %v, want %v", tt.name, got, out.want)
-			}
+			file, err := ioutil.ReadFile(tmpTutorial)
+			assert.NoError(t, err)
+
+			var holder = TutorialHolder{}
+			err = json.Unmarshal(file, &holder)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, holder)
 		})
 	}
 

--- a/pkg/rtutorial/tutorial.go
+++ b/pkg/rtutorial/tutorial.go
@@ -16,7 +16,7 @@
 
 package rtutorial
 
-const TutorialPath = "%s/tutorial.json"
+const TutorialFile = "tutorial.json"
 
 const DefaultTutorial = "enabled"
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
* Adding flag support to `rit tutorial` command (closes #715 )
* Removing file manager dependencies on rtutorial package
* Refactoring `rtutorial` tests (closes #795 )
* Refactoring tests for cmd/tutorial command (contributes to #776 )

### How to verify it
You can run `rit tutorial --enabled=false` and check that the tutorial has been disabled

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Added flag support for rit tutorial command
