### PR TITLE
[BUGFIX] - Fix build with build.sh

### DIFF
--- a/pkg/formula/runner/local/pre_run.go
+++ b/pkg/formula/runner/local/pre_run.go
@@ -128,9 +128,7 @@ func (pr PreRunManager) buildFormula(formulaPath string) error {
 		if err := pr.shell.Build(info); err != nil {
 			return err
 		}
-	}
-
-	if err := pr.make.Build(info); err != nil { // Build formula with Makefile
+	} else if err := pr.make.Build(info); err != nil { // Build formula with Makefile
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Fabiano Chiareto Fernandes <fabiano.fernandes@zup.com.br>

### Description
The build process checks for the existence of the build.sh file in the formula and, if not found, proceed to the build through the makefile.

But when the formula has both files, it generates an error, because first the build.sh is executed and then the makefile, and this error is captured by the cli as a build execution error.

The formula template is using both files to maintain compatibility with previous versions of the cli.

### How to verify it

Create a new formula such as shell-bat. (Commons release 2.15.1)
 When executing the first time, there will be a build error message with makefile, as in the image below.

### Changelog
- Fix build process when the formula has build.sh and makefile
