### PR TITLE
Fixing delete credential empty fields bug

### DIFF
--- a/pkg/cmd/delete_credential.go
+++ b/pkg/cmd/delete_credential.go
@@ -112,7 +112,7 @@ func (d *deleteCredentialCmd) resolvePrompt(context string) (inputDeleteCredenti
 		return inputDeleteCredential{}, errors.New("you have no defined credentials in this env")
 	}
 
-	providers := make([]string, len(data))
+	providers := make([]string, 0, len(data))
 	for _, c := range data {
 		providers = append(providers, c.Provider)
 	}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
When running `rit delete credential` some empty options could be found
Closes #852 

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Fixing empty credentials on rit delete credential
