### PR TITLE
Update repo fix

### DIFF
--- a/pkg/cmd/update_repo.go
+++ b/pkg/cmd/update_repo.go
@@ -103,7 +103,7 @@ func (up updateRepoCmd) runPrompt() CommandRunnerFunc {
 			return err
 		}
 
-		flagAll := (name == updateOptionAll)
+		flagAll := name == updateOptionAll
 
 		var repoToUpdate []formula.Repo
 
@@ -111,8 +111,8 @@ func (up updateRepoCmd) runPrompt() CommandRunnerFunc {
 			repoToUpdate = externalRepos
 		} else {
 			for i := range externalRepos {
-				if repos[i].Name == formula.RepoName(name) {
-					repoToUpdate = append(repoToUpdate, repos[i])
+				if externalRepos[i].Name == formula.RepoName(name) {
+					repoToUpdate = append(repoToUpdate, externalRepos[i])
 					break
 				}
 			}

--- a/pkg/cmd/update_repo_test.go
+++ b/pkg/cmd/update_repo_test.go
@@ -73,7 +73,7 @@ func TestUpdateRepoRun(t *testing.T) {
 			in: in{
 				repo: RepositoryListUpdaterCustomMock{
 					list: func() (formula.Repos, error) {
-						return formula.Repos{*repoTest, *repoTest2}, nil
+						return formula.Repos{*repoTest2, *repoTest}, nil
 					},
 					update: func(name formula.RepoName, version formula.RepoVersion) error {
 						return nil
@@ -275,6 +275,9 @@ func TestUpdateRepoRun(t *testing.T) {
 
 			newReader := strings.NewReader(tt.inputStdin)
 			newUpdateRepoStdin.SetIn(newReader)
+			newUpdateRepoStdin.SetArgs([]string{})
+
+			newUpdateRepoPrompt.SetArgs([]string{})
 
 			if err := newUpdateRepoPrompt.Execute(); (err != nil) != tt.wantErr {
 				t.Errorf("Prompt command error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
When a user tries to update a specific repo, the cli interrupts the execution right before listing the release versions. This is a bug that is preventing users to update their repos. This was causing due to the existence of local repos for the user. The array used to select the correct repo was the full array with local repos as well. 

Closes #851 

### How to verify it
Run `rit update repo`, select a **specific** repo and have some local repos configured. It should list the releases and update normally.

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Fix rit update repo now allows updates of specific repo

<img width="662" alt="Screen Shot 2021-02-18 at 17 04 14" src="https://user-images.githubusercontent.com/68074718/108414770-6040d380-720b-11eb-97fd-a497ef84f236.png">
