### PR TITLE
Improved error msg on invalid value on list input

### DIFF
--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	errInvalidInputItemsMsg = "only these input items [%s] are accepted in the %q flag"
+	errInvalidInputItemsMsg = "the value [%v] is not valid, only these input items [%s] are accepted in the %q flag"
 )
 
 type InputManager struct {
@@ -119,7 +119,7 @@ func validateItem(i formula.Input, inputVal string) error {
 	if len(i.Items) > 0 && !i.Items.Contains(inputVal) {
 		items := strings.Join(i.Items, ", ")
 		formattedName := fmt.Sprintf("--%s", i.Name)
-		return fmt.Errorf(errInvalidInputItemsMsg, items, formattedName)
+		return fmt.Errorf(errInvalidInputItemsMsg, inputVal, items, formattedName)
 	}
 
 	return nil

--- a/pkg/formula/input/flag/flag_test.go
+++ b/pkg/formula/input/flag/flag_test.go
@@ -75,7 +75,7 @@ func TestInputs(t *testing.T) {
 			in: in{
 				valueForList: "invalid",
 			},
-			want: errors.New("only these input items [in_list1, in_list2, in_list3, in_listN] are accepted in the \"--sample_list\" flag"),
+			want: errors.New("the value [invalid] is not valid, only these input items [in_list1, in_list2, in_list3, in_listN] are accepted in the \"--sample_list\" flag"),
 		},
 		{
 			name: "invalid operator",


### PR DESCRIPTION
Signed-off-by: Fabiano Chiareto Fernandes <fabiano.fernandes@zup.com.br>


### Description
Improved error message when an invalid value is passed to an input list via input flag or stdin.

When a value is passed with a coding error or hidden character such as line break, the cli informs that the value passed is not valid, but there is no value that it received, making it difficult to identify the error.

In the example below of a run on windows, the accented character gave an encode problem and this was not possible to identify only with the old error message.

### How to verify it

To check the error, I created two bat formulas with input_list with accented items, and called one formula inside the other, so the encoding error generated an error in the execution of the daughter formula, but it was not possible to identify the error.

**Before correction**
![image](https://user-images.githubusercontent.com/58859234/108791377-affe0280-755d-11eb-8ceb-4df900d71fc8.png)

**After correction**
![image](https://user-images.githubusercontent.com/58859234/108791265-69a8a380-755d-11eb-81f2-ffe6d3b5e503.png)


### Changelog
Improved error message when an invalid value is passed to an input list via input flag or stdin.
