### PR TITLE
test: github testify

### DIFF
--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -69,7 +69,7 @@ func (in DefaultRepoInfo) LatestTagUrl() string { //nolint:stylecheck
 }
 
 // TokenHeader returns the Authorization value formatted for Github API integration
-// e.g. "token f39c5aca-858f-4a04-9ca3-5104d02b9c56"
+// e.g. "token some_token"
 func (in DefaultRepoInfo) TokenHeader() string {
 	return fmt.Sprintf("token %s", in.token)
 }

--- a/pkg/git/github/github_test.go
+++ b/pkg/git/github/github_test.go
@@ -17,155 +17,53 @@
 package github
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/ZupIT/ritchie-cli/pkg/git"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	repoUrl = "http://github.com/username/repo-name"
+	token   = "some_token"
+	version = "0.0.3"
 )
 
 func TestLatestTagUrl(t *testing.T) {
-	type in struct {
-		Url   string
-		Token string
-	}
-	tests := []struct {
-		name string
-		in   in
-		want string
-	}{
-		{
-			name: "Generate LatestTagUrlWithSuccess",
-			in: in{
-				Url: "http://github.com/zupIt/ritchie-cli",
-			},
-			want: "https://api.github.com/repos/zupIt/ritchie-cli/releases/latest",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			in := NewRepoInfo(tt.in.Url, tt.in.Token)
+	const want = "https://api.github.com/repos/username/repo-name/releases/latest"
+	repoInfo := NewRepoInfo(repoUrl, token)
+	latestTagsUrl := repoInfo.LatestTagUrl()
 
-			if got := in.LatestTagUrl(); got != tt.want {
-				t.Errorf("LatestTagUrl() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	assert.Equal(t, want, latestTagsUrl)
 }
 
 func TestTagsUrl(t *testing.T) {
-	type in struct {
-		Url   string
-		Token string
-	}
-	tests := []struct {
-		name string
-		in   in
-		want string
-	}{
-		{
-			name: "Generate LatestTagUrlWithSuccess",
-			in: in{
-				Url: "http://github.com/zupIt/ritchie-cli",
-			},
-			want: "https://api.github.com/repos/zupIt/ritchie-cli/releases",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			in := NewRepoInfo(tt.in.Url, tt.in.Token)
+	const want = "https://api.github.com/repos/username/repo-name/releases"
+	repoInfo := NewRepoInfo(repoUrl, token)
+	tagsUrl := repoInfo.TagsUrl()
 
-			if got := in.TagsUrl(); got != tt.want {
-				t.Errorf("TagsUrl() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	assert.Equal(t, want, tagsUrl)
 }
 
-func TestRepoInfo_TokenHeader(t *testing.T) {
-	type in struct {
-		Url   string
-		Token string
-	}
-	tests := []struct {
-		name string
-		in   in
-		want string
-	}{
-		{
-			name: "Generate LatestTagUrlWithSuccess",
-			in: in{
-				Url:   "http://github.com/zupIt/ritchie-cli",
-				Token: "any_token",
-			},
-			want: "token any_token",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			in := NewRepoInfo(tt.in.Url, tt.in.Token)
+func TestTokenHeader(t *testing.T) {
+	const want = "token some_token"
+	repoInfo := NewRepoInfo(repoUrl, token)
+	tokenHeader := repoInfo.TokenHeader()
 
-			if got := in.TokenHeader(); got != tt.want {
-				t.Errorf("TokenHeader() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	assert.Equal(t, want, tokenHeader)
 }
 
 func TestZipUrl(t *testing.T) {
-	type in struct {
-		Url     string
-		Token   string
-		version string
-	}
+	const want = "https://api.github.com/repos/username/repo-name/zipball/0.0.3"
+	repoInfo := NewRepoInfo(repoUrl, token)
+	zipUrl := repoInfo.ZipUrl(version)
 
-	tests := []struct {
-		name string
-		in   in
-		want string
-	}{
-		{
-			name: "Generate LatestTagUrlWithSuccess",
-			in: in{
-				Url:     "http://github.com/zupIt/ritchie-cli",
-				version: "0.0.3",
-			},
-			want: "https://api.github.com/repos/zupIt/ritchie-cli/zipball/0.0.3",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			in := NewRepoInfo(tt.in.Url, tt.in.Token)
-			if got := in.ZipUrl(tt.in.version); got != tt.want {
-				t.Errorf("ZipUrl() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	assert.Equal(t, want, zipUrl)
 }
 
-func TestTags_Names(t *testing.T) {
-	tests := []struct {
-		name string
-		t    git.Tags
-		want []string
-	}{
-		{
-			name: "Return tags name",
-			t: git.Tags{
-				{
-					Name: "tag1",
-				},
-				{
-					Name: "tag2",
-				},
-			},
-			want: []string{"tag1", "tag2"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.t.Names(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Names() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+func TestToken(t *testing.T) {
+	const want = "some_token"
+	repoInfo := NewRepoInfo(repoUrl, token)
+	token := repoInfo.Token()
+
+	assert.Equal(t, want, token)
 }

--- a/pkg/git/github/repository.go
+++ b/pkg/git/github/repository.go
@@ -56,13 +56,13 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	apiURL := info.TagsUrl()
 	res, err := re.performRequest(info, apiURL)
 	if err != nil {
-		return nil, err
+		return git.Tags{}, err
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
-		return nil, errors.New(res.Status + "-" + string(all))
+		return git.Tags{}, errors.New(res.Status + "-" + string(all))
 	}
 
 	var tags git.Tags

--- a/pkg/git/github/repository.go
+++ b/pkg/git/github/repository.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -39,49 +38,31 @@ func NewRepoManager(client *http.Client) RepoManager {
 
 func (re RepoManager) Zipball(info git.RepoInfo, version string) (io.ReadCloser, error) {
 	zipURL := info.ZipUrl(version)
-	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, zipURL, nil)
+	res, err := re.performRequest(info, zipURL)
 	if err != nil {
 		return nil, err
 	}
 
-	if info.Token() != "" {
-		authToken := info.TokenHeader()
-		req.Header.Add(headers.Authorization, authToken)
+	if res.StatusCode != http.StatusOK {
+		defer res.Body.Close()
+		all, _ := ioutil.ReadAll(res.Body)
+		return nil, errors.New(res.Status + "-" + string(all))
 	}
 
-	req.Header.Add(headers.Accept, "application/vnd.github.v3+json")
-	resp, err := re.client.Do(req) //nolint:bodyclose
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.Body, nil
+	return res.Body, nil
 }
 
 func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	apiURL := info.TagsUrl()
-	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, apiURL, nil)
+	res, err := re.performRequest(info, apiURL)
 	if err != nil {
-		return git.Tags{}, err
-	}
-
-	if info.Token() != "" {
-		authToken := info.TokenHeader()
-		req.Header.Add(headers.Authorization, authToken)
-	}
-
-	req.Header.Add(headers.Accept, "application/vnd.github.v3+json")
-	res, err := re.client.Do(req)
-	if err != nil {
-		return git.Tags{}, err
+		return nil, err
 	}
 
 	defer res.Body.Close()
-
 	if res.StatusCode != http.StatusOK {
-		errorMessage := fmt.Sprintf("There was an error adding the repository,"+
-			" status: %d - %s.", res.StatusCode, http.StatusText(res.StatusCode))
-		return git.Tags{}, errors.New(errorMessage)
+		all, _ := ioutil.ReadAll(res.Body)
+		return nil, errors.New(res.Status + "-" + string(all))
 	}
 
 	var tags git.Tags
@@ -94,29 +75,15 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 func (re RepoManager) LatestTag(info git.RepoInfo) (git.Tag, error) {
 	apiURL := info.LatestTagUrl()
-	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, apiURL, nil)
-	if err != nil {
-		return git.Tag{}, err
-	}
-
-	if info.Token() != "" {
-		authToken := info.TokenHeader()
-		req.Header.Add(headers.Authorization, authToken)
-	}
-
-	req.Header.Add(headers.Accept, "application/vnd.github.v3+json")
-	res, err := re.client.Do(req)
+	res, err := re.performRequest(info, apiURL)
 	if err != nil {
 		return git.Tag{}, err
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return git.Tag{}, err
-		}
-		return git.Tag{}, errors.New(string(b))
+		all, _ := ioutil.ReadAll(res.Body)
+		return git.Tag{}, errors.New(res.Status + "-" + string(all))
 	}
 
 	githubTag := struct {
@@ -131,4 +98,24 @@ func (re RepoManager) LatestTag(info git.RepoInfo) (git.Tag, error) {
 		Description: githubTag.ReleaseDescription,
 	}
 	return tag, nil
+}
+
+func (re RepoManager) performRequest(info git.RepoInfo, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Token() != "" {
+		authToken := info.TokenHeader()
+		req.Header.Add(headers.Authorization, authToken)
+	}
+
+	req.Header.Add(headers.Accept, "application/vnd.github.v3+json")
+	res, err := re.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/pkg/git/github/repository_test.go
+++ b/pkg/git/github/repository_test.go
@@ -20,11 +20,168 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
+	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/git"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestTags(t *testing.T) {
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(PayloadListAllTags))
+	}))
+
+	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+	}))
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		info    info
+		want    git.Tags
+		wantErr string
+	}{
+		{
+			name:   "Run with success",
+			client: mockServer.Client(),
+			info: info{
+				tagsUrl: mockServer.URL,
+				token:   "some_token",
+			},
+			want: git.Tags{
+				{
+					Name: "v1.0.0",
+				},
+			},
+		},
+		{
+			name:   "Return err when request fail",
+			client: mockServerThatFail.Client(),
+			info: info{
+				tagsUrl: mockServerThatFail.URL,
+			},
+			want:    git.Tags{},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			git := &mocks.RepoInfo{}
+			git.On("Token").Return(tt.info.token)
+			git.On("TagsUrl").Return(tt.info.tagsUrl)
+			re := NewRepoManager(tt.client)
+			got, err := re.Tags(git)
+			if err == nil {
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLatestTag(t *testing.T) {
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(PayloadListLastTags))
+	}))
+
+	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+	}))
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		info    info
+		want    git.Tag
+		wantErr string
+	}{
+		{
+			name:   "Run with success",
+			client: mockServer.Client(),
+			info: info{
+				latestTagUrl: mockServer.URL,
+				token:        "some_token",
+			},
+			want: git.Tag{Name: "v1.0.0", Description: "Description of the release"},
+		},
+		{
+			name:   "Return err when request fail",
+			client: mockServerThatFail.Client(),
+			info: info{
+				latestTagUrl: mockServerThatFail.URL,
+			},
+			want:    git.Tag{},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			git := &mocks.RepoInfo{}
+			git.On("Token").Return(tt.info.token)
+			git.On("Token").Return(tt.info.token)
+			git.On("LatestTagUrl").Return(tt.info.latestTagUrl)
+			re := NewRepoManager(tt.client)
+			got, err := re.LatestTag(git)
+			if err == nil {
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestZipball(t *testing.T) {
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		data := `zipValue`
+		_, _ = writer.Write([]byte(data))
+	}))
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		info    info
+		version string
+		want    string
+	}{
+		{
+			name:   "Run with success",
+			client: mockServer.Client(),
+			info: info{
+				zipUrl: mockServer.URL,
+				token:  "some_token",
+			},
+			version: "1.0.0",
+			want:    "zipValue",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			git := &mocks.RepoInfo{}
+			git.On("Token").Return(tt.info.token)
+			git.On("TokenHeader").Return(tt.info.tokenHeader)
+			git.On("ZipUrl", tt.version).Return(tt.info.zipUrl)
+			re := RepoManager{client: tt.client}
+			got, err := re.Zipball(git, tt.version)
+			if err != nil {
+				assert.EqualError(t, err, tt.want)
+			} else {
+				result, err := ioutil.ReadAll(got)
+				if assert.Nil(t, err) {
+					assert.Equal(t, tt.want, string(result))
+				}
+			}
+		})
+	}
+}
 
 const (
 	PayloadListLastTags = `
@@ -181,211 +338,10 @@ const (
 ]`
 )
 
-func TestTags(t *testing.T) {
-
-	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		_, _ = writer.Write([]byte(PayloadListAllTags))
-	}))
-
-	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(http.StatusBadRequest)
-	}))
-
-	type in struct {
-		client *http.Client
-		info   git.RepoInfo
-	}
-	tests := []struct {
-		name    string
-		in      in
-		want    git.Tags
-		wantErr bool
-	}{
-		{
-			name: "Run with success",
-			in: in{
-				client: mockServer.Client(),
-				info: RepoInfoCustomMock{
-					tagsUrl: mockServer.URL,
-					token:   "some_token",
-				},
-			},
-			want: git.Tags{
-				{
-					Name: "v1.0.0",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Return err when request fail",
-			in: in{
-				client: mockServerThatFail.Client(),
-				info: RepoInfoCustomMock{
-					tagsUrl: mockServerThatFail.URL,
-				},
-			},
-			want:    git.Tags{},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			re := NewRepoManager(tt.in.client)
-
-			got, err := re.Tags(tt.in.info)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Tags() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Tags() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestLatestTag(t *testing.T) {
-
-	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		_, _ = writer.Write([]byte(PayloadListLastTags))
-	}))
-
-	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(http.StatusBadRequest)
-	}))
-
-	type in struct {
-		client *http.Client
-		info   git.RepoInfo
-	}
-	tests := []struct {
-		name    string
-		in      in
-		want    git.Tag
-		wantErr bool
-	}{
-		{
-			name: "Run with success",
-			in: in{
-				client: mockServer.Client(),
-				info: RepoInfoCustomMock{
-					latestTagUrl: mockServer.URL,
-					token:        "some_token",
-				},
-			},
-			want:    git.Tag{Name: "v1.0.0", Description: "Description of the release"},
-			wantErr: false,
-		},
-		{
-			name: "Return err when request fail",
-			in: in{
-				client: mockServerThatFail.Client(),
-				info: RepoInfoCustomMock{
-					latestTagUrl: mockServerThatFail.URL,
-				},
-			},
-			want:    git.Tag{},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			re := NewRepoManager(tt.in.client)
-
-			got, err := re.LatestTag(tt.in.info)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LatestTag() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LatestTag() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestZipball(t *testing.T) {
-
-	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		data := `zipValue`
-		_, _ = writer.Write([]byte(data))
-	}))
-
-	type in struct {
-		client  *http.Client
-		info    git.RepoInfo
-		version string
-	}
-	tests := []struct {
-		name    string
-		in      in
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "Run with success",
-			in: in{
-				client: mockServer.Client(),
-				info: RepoInfoCustomMock{
-					zipUrl: func(version string) string {
-						return mockServer.URL
-					},
-					token: "some_token",
-				},
-				version: "1.0.0",
-			},
-			want:    "zipValue",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			re := RepoManager{
-				client: tt.in.client,
-			}
-			got, err := re.Zipball(tt.in.info, tt.in.version)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Zipball() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			result, err := ioutil.ReadAll(got)
-			if err != nil {
-				t.Errorf("fail to parse result")
-			}
-
-			if string(result) != tt.want {
-				t.Errorf("Zipball() got = %v, want %v", got, tt.want)
-			}
-
-		})
-	}
-}
-
-type RepoInfoCustomMock struct {
-	zipUrl       func(version string) string
+type info struct {
+	zipUrl       string
 	tagsUrl      string
 	latestTagUrl string
-	tokenHeader  string
 	token        string
-}
-
-func (m RepoInfoCustomMock) ZipUrl(version string) string {
-	return m.zipUrl(version)
-}
-
-func (m RepoInfoCustomMock) TagsUrl() string {
-	return m.tagsUrl
-}
-
-func (m RepoInfoCustomMock) LatestTagUrl() string {
-	return m.latestTagUrl
-}
-
-func (m RepoInfoCustomMock) TokenHeader() string {
-	return m.tokenHeader
-}
-
-func (m RepoInfoCustomMock) Token() string {
-	return m.token
+	tokenHeader  string
 }


### PR DESCRIPTION
### Description
This pr **adds the lib testify to the tests of the github package** _(github and repository)_.

In addition, a refactoring has been added to the github.go and repository.go files to facilitate the development of the tests and, consequently, increase the coverage of the package / project.

Close #792  

### How to verify it
1. `check` the unit testing pipeline

### Changelog
Add testify to the tests of the github package
