### PR TITLE
Adding safety check to workspace add

### DIFF
--- a/pkg/cmd/add_workspace.go
+++ b/pkg/cmd/add_workspace.go
@@ -47,18 +47,9 @@ func NewAddWorkspaceCmd(
 	return cmd
 }
 
-func (a addWorkspaceCmd) runFormula() CommandRunnerFunc {
+func (a *addWorkspaceCmd) runFormula() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().NFlag() == 0 {
-			wspace, err := addWorkspaceFromPrompt(a)
-			if err != nil {
-				return err
-			}
-
-			return a.workspace.Add(wspace)
-		}
-
-		wspace, err := addWorkspaceFromFlags(cmd)
+		wspace, err := a.resolveInput(cmd)
 		if err != nil {
 			return err
 		}
@@ -67,7 +58,14 @@ func (a addWorkspaceCmd) runFormula() CommandRunnerFunc {
 	}
 }
 
-func addWorkspaceFromFlags(cmd *cobra.Command) (formula.Workspace, error) {
+func (a *addWorkspaceCmd) resolveInput(cmd *cobra.Command) (formula.Workspace, error) {
+	if IsFlagInput(cmd) {
+		return a.resolveFlags(cmd)
+	}
+	return a.resolvePrompt()
+}
+
+func (a *addWorkspaceCmd) resolveFlags(cmd *cobra.Command) (formula.Workspace, error) {
 	workspaceName, _ := cmd.Flags().GetString(workspaceNameFlag)
 	workspacePath, _ := cmd.Flags().GetString(workspacePathFlag)
 
@@ -83,7 +81,7 @@ func addWorkspaceFromFlags(cmd *cobra.Command) (formula.Workspace, error) {
 	return wspace, nil
 }
 
-func addWorkspaceFromPrompt(a addWorkspaceCmd) (formula.Workspace, error) {
+func (a *addWorkspaceCmd) resolvePrompt() (formula.Workspace, error) {
 	workspaceName, err := a.input.Text("Enter the name of workspace", true)
 	if err != nil {
 		return formula.Workspace{}, err

--- a/pkg/formula/workspace/workspace.go
+++ b/pkg/formula/workspace/workspace.go
@@ -65,6 +65,11 @@ func (m Manager) Add(workspace formula.Workspace) error {
 	if workspace.Dir == m.defaultWorkspaceDir {
 		return nil
 	}
+
+	// Avoid finishing separators
+	if last := len(workspace.Dir) - 1; last >= 0 && workspace.Dir[last] == filepath.Separator {
+		workspace.Dir = workspace.Dir[:last]
+	}
 	if _, err := os.Stat(workspace.Dir); os.IsNotExist(err) {
 		return ErrInvalidWorkspace
 	}

--- a/pkg/formula/workspace/workspace_test.go
+++ b/pkg/formula/workspace/workspace_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/formula"
@@ -60,6 +61,14 @@ func TestWorkspaceManagerAdd(t *testing.T) {
 			workspace: formula.Workspace{
 				Name: "zup",
 				Dir:  fullDir,
+			},
+		},
+		{
+			name:          "success create with trailing separator",
+			workspacePath: tmpDir,
+			workspace: formula.Workspace{
+				Name: "zup2",
+				Dir:  fullDir + string(filepath.Separator),
 			},
 		},
 		{
@@ -102,7 +111,7 @@ func TestWorkspaceManagerAdd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			localBuilder := &mocks.LocalBuilderMock{}
-			localBuilder.On("Init", tt.workspace.Dir, tt.workspace.Name).Return("", nil)
+			localBuilder.On("Init", mock.AnythingOfType("string"), tt.workspace.Name).Return("", nil)
 
 			workspace := New(tt.workspacePath, tt.workspacePath, dirManager, localBuilder)
 			got := workspace.Add(tt.workspace)
@@ -118,7 +127,7 @@ func TestWorkspaceManagerAdd(t *testing.T) {
 				err = json.Unmarshal(file, &workspaces)
 				assert.NoError(t, err)
 				pathName := workspaces[tt.workspace.Name]
-				assert.Equal(t, tt.workspace.Dir, pathName)
+				assert.Contains(t, tt.workspace.Dir, pathName)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Henrique Moraes <henrique.moraes@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
If a user tries to add a workspace with a trailing separator, it breaks the autobuild feature when mapping the workspace to the `.rit` directory

### How to verify it
Run `rit add workspace`, add a trailing separator on the path (i.e: `/my/repo/`), run a formula, edit, and run again. Autobuild should work normally

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Fixing bug when adding trailing separator to workspace