### PR TITLE
Multiselect flag support

### DIFF
--- a/pkg/cmd/formula.go
+++ b/pkg/cmd/formula.go
@@ -224,11 +224,10 @@ func (f FormulaCommand) addInputFlags(def formula.Definition, flags *pflag.FlagS
 			continue
 		}
 
-		switch in.Type {
-		case input.TextType, input.PassType, input.DynamicType:
-			flags.String(in.Name, in.Default, in.Tutorial)
-		case input.BoolType:
+		if in.Type == input.BoolType {
 			flags.Bool(in.Name, false, in.Tutorial)
+		} else {
+			flags.String(in.Name, in.Default, in.Tutorial)
 		}
 	}
 }

--- a/pkg/formula/formula_test.go
+++ b/pkg/formula/formula_test.go
@@ -20,8 +20,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ZupIT/ritchie-cli/pkg/os/osutil"
 )
@@ -43,18 +44,14 @@ func TestFormulaPath(t *testing.T) {
 	want := filepath.Join(home, "repos", "commons", "scaffold", "coffee-java")
 	got := def.FormulaPath(home)
 
-	if want != got {
-		t.Errorf("FormulaPath got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestTmpWorkDirPath(t *testing.T) {
 	want := filepath.Join(home, TmpDir)
 	gotTmpDir := def.TmpWorkDirPath(home)
 
-	if !strings.Contains(gotTmpDir, want) {
-		t.Errorf("TmpWorkDirPath got tmp dir %v, want some string that contains %v", gotTmpDir, want)
-	}
+	assert.Contains(t, gotTmpDir, want)
 }
 
 func TestBinPath(t *testing.T) {
@@ -62,9 +59,7 @@ func TestBinPath(t *testing.T) {
 	formulaPath := def.FormulaPath(home)
 	got := def.BinPath(formulaPath)
 
-	if want != got {
-		t.Errorf("BinPath got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestBinFilePath(t *testing.T) {
@@ -78,9 +73,7 @@ func TestBinFilePath(t *testing.T) {
 	formulaPath := def.FormulaPath(home)
 	got := def.BinFilePath(formulaPath)
 
-	if want != got {
-		t.Errorf("BinFilePath got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestFormulaCmdName(t *testing.T) {
@@ -91,9 +84,7 @@ func TestFormulaCmdName(t *testing.T) {
 
 	got := create.FormulaCmdName()
 
-	if want != got {
-		t.Errorf("FormulaName got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestPkgName(t *testing.T) {
@@ -104,9 +95,7 @@ func TestPkgName(t *testing.T) {
 
 	got := create.PkgName()
 
-	if want != got {
-		t.Errorf("PkgName got %v, want %v", got, want)
-	}
+	assert.Equal(t, got, want)
 }
 
 func TestConfigPath(t *testing.T) {
@@ -114,7 +103,5 @@ func TestConfigPath(t *testing.T) {
 
 	got := def.ConfigPath(def.FormulaPath(home))
 
-	if want != got {
-		t.Errorf("TestConfigPath got %v, want %v", got, want)
-	}
+	assert.Equal(t, got, want)
 }

--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -137,7 +137,7 @@ func validateMultiselect(i formula.Input, inputVal string) error {
 		if !i.Items.Contains(value) {
 			items := strings.Join(i.Items, ", ")
 			formattedName := fmt.Sprintf("--%s", i.Name)
-			return fmt.Errorf(errInvalidInputItemsMsg, inputVal, items, formattedName)
+			return fmt.Errorf(errInvalidInputItemsMsg, value, items, formattedName)
 		}
 	}
 

--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -59,13 +59,19 @@ func (in InputManager) Inputs(cmd *exec.Cmd, setup formula.Setup, flags *pflag.F
 		}
 
 		switch i.Type {
-		case input.TextType, input.PassType, input.DynamicType:
+		case input.TextType, input.PassType, input.DynamicType, input.ListType:
 			inputVal, err = flags.GetString(i.Name)
 			if err := validateItem(i, inputVal); err != nil {
 				return err
 			}
 
 			if err := matchWithRegex(i, inputVal); err != nil {
+				return err
+			}
+
+		case input.Multiselect:
+			inputVal, err = flags.GetString(i.Name)
+			if err := validateMultiselect(i, inputVal); err != nil {
 				return err
 			}
 
@@ -120,6 +126,19 @@ func validateItem(i formula.Input, inputVal string) error {
 		items := strings.Join(i.Items, ", ")
 		formattedName := fmt.Sprintf("--%s", i.Name)
 		return fmt.Errorf(errInvalidInputItemsMsg, items, formattedName)
+	}
+
+	return nil
+}
+
+func validateMultiselect(i formula.Input, inputVal string) error {
+	allValues := strings.Split(inputVal, input.MultiselectSeparator)
+	for _, value := range allValues {
+		if !i.Items.Contains(value) {
+			items := strings.Join(i.Items, ", ")
+			formattedName := fmt.Sprintf("--%s", i.Name)
+			return fmt.Errorf(errInvalidInputItemsMsg, items, formattedName)
+		}
 	}
 
 	return nil

--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -69,7 +69,7 @@ func (in InputManager) Inputs(cmd *exec.Cmd, setup formula.Setup, flags *pflag.F
 				return err
 			}
 
-		case input.Multiselect:
+		case input.MultiselectType:
 			inputVal, err = flags.GetString(i.Name)
 			if err := validateMultiselect(i, inputVal); err != nil {
 				return err
@@ -137,7 +137,7 @@ func validateMultiselect(i formula.Input, inputVal string) error {
 		if !i.Items.Contains(value) {
 			items := strings.Join(i.Items, ", ")
 			formattedName := fmt.Sprintf("--%s", i.Name)
-			return fmt.Errorf(errInvalidInputItemsMsg, items, formattedName)
+			return fmt.Errorf(errInvalidInputItemsMsg, inputVal, items, formattedName)
 		}
 	}
 

--- a/pkg/formula/input/flag/flag_test.go
+++ b/pkg/formula/input/flag/flag_test.go
@@ -78,6 +78,13 @@ func TestInputs(t *testing.T) {
 			want: errors.New("the value [invalid] is not valid, only these input items [in_list1, in_list2, in_list3, in_listN] are accepted in the \"--sample_list\" flag"),
 		},
 		{
+			name: "invalid value for multiselect item",
+			in: in{
+				valueForMultiselect: "invalid",
+			},
+			want: errors.New("the value [invalid] is not valid, only these input items [multi1, multi2, multi3, multiN] are accepted in the \"--sample_multiselect\" flag"),
+		},
+		{
 			name: "invalid operator",
 			in: in{
 				operator: "eq",
@@ -116,6 +123,8 @@ func TestInputs(t *testing.T) {
 					}
 				case input.BoolType:
 					flags.Bool(in.Name, false, in.Tutorial)
+				case input.MultiselectType:
+					flags.String(in.Name, tt.in.valueForMultiselect, in.Tutorial)
 				}
 			}
 
@@ -133,22 +142,24 @@ func TestInputs(t *testing.T) {
 }
 
 type in struct {
-	creResolver      credential.Resolver
-	defaultFlagValue string
-	valueForList     string
-	valueForRegex    string
-	regex            string
-	operator         string
+	creResolver         credential.Resolver
+	defaultFlagValue    string
+	valueForList        string
+	valueForMultiselect string
+	valueForRegex       string
+	regex               string
+	operator            string
 }
 
 func defaultFields(testFields in) in {
 	defaultFields := in{
-		creResolver:      envResolverMock{in: "test"},
-		defaultFlagValue: "text",
-		valueForList:     "in_list2",
-		valueForRegex:    "text_ok",
-		regex:            "text_ok",
-		operator:         "==",
+		creResolver:         envResolverMock{in: "test"},
+		defaultFlagValue:    "text",
+		valueForList:        "in_list2",
+		valueForMultiselect: "multi1",
+		valueForRegex:       "text_ok",
+		regex:               "text_ok",
+		operator:            "==",
 	}
 
 	if testFields.creResolver != nil {
@@ -165,6 +176,10 @@ func defaultFields(testFields in) in {
 
 	if testFields.valueForList != "" {
 		defaultFields.valueForList = testFields.valueForList
+	}
+
+	if testFields.valueForMultiselect != "" {
+		defaultFields.valueForMultiselect = testFields.valueForMultiselect
 	}
 
 	if testFields.regex != "" {
@@ -265,6 +280,18 @@ const inputJson = `[
         "type": "password",
         "label": "Pick: ",
 		"tutorial": "Add a secret password for this field."
+    },
+	{
+        "name": "sample_multiselect",
+        "type": "multiselect",
+		"items": [
+            "multi1",
+            "multi2",
+            "multi3",
+            "multiN"
+        ],
+        "label": "Pick: ",
+		"tutorial": "Select any of the options."
     },
     {
         "name": "test_resolver",

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -13,12 +13,13 @@ type InputTextDefault interface {
 }
 
 const (
-	TextType    = "text"
-	ListType    = "list"
-	BoolType    = "bool"
-	PassType    = "password"
-	DynamicType = "dynamic"
-	Multiselect = "multiselect"
+	TextType             = "text"
+	ListType             = "list"
+	BoolType             = "bool"
+	PassType             = "password"
+	DynamicType          = "dynamic"
+	Multiselect          = "multiselect"
+	MultiselectSeparator = "|"
 )
 
 // addEnv Add environment variable to run formulas.

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -18,7 +18,7 @@ const (
 	BoolType             = "bool"
 	PassType             = "password"
 	DynamicType          = "dynamic"
-	Multiselect          = "multiselect"
+	MultiselectType      = "multiselect"
 	MultiselectSeparator = "|"
 )
 

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -149,7 +149,7 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 		if err != nil {
 			return "", err
 		}
-		return strings.Join(sl, "|"), nil
+		return strings.Join(sl, input.MultiselectSeparator), nil
 	default:
 		return in.cred.Resolve(i.Type)
 	}

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -141,7 +141,7 @@ func (in InputManager) inputTypeToPrompt(items []string, i formula.Input) (strin
 			return "", err
 		}
 		return in.List(i.Label, dl, i.Tutorial)
-	case input.Multiselect:
+	case input.MultiselectType:
 		if len(items) == 0 {
 			return "", fmt.Errorf(EmptyItems, i.Name)
 		}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
When adding a `multiselect` input, Ritchie could not translate it into flags. We need to take this case into account

* Adds support to `list` input type command
* Adds support to `list` input type input
* Adds support to `multiselect` input type command
* Adds support to `multiselect` input type input
* Refactors tests on `formula` package
* Makes a forward-compatible solution for flag reading by extracting any new types as string

Closes #881 
Closes #791 

### How to verify it
Add a `multiselect` input and run `--help`, the input should be listed

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
Supporting flags for multiselect input
