### PR TITLE
Changing conditional to only return an error when the conditional input variable does not exist in the config.json variable list

### DIFF
--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -50,7 +50,7 @@ func (in InputManager) Inputs(cmd *exec.Cmd, setup formula.Setup, flags *pflag.F
 		var inputVal string
 		var err error
 
-		conditionPass, err := input.VerifyConditional(cmd, i)
+		conditionPass, err := input.VerifyConditional(cmd, i, inputs)
 		if err != nil {
 			return err
 		}

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -40,7 +40,6 @@ func HasRegex(input formula.Input) bool {
 	return len(input.Pattern.Regex) > 0
 }
 
-
 func inputConditionVariableExistsOnInputList(variable string, inputList formula.Inputs) (bool) {
 	for _, inputListElement := range inputList {
 		if inputListElement.Name == variable {

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -71,7 +71,7 @@ func VerifyConditional(cmd *exec.Cmd, input formula.Input, inputList formula.Inp
 	}
 
 	if value == "" {
-		return true, nil
+		return false, nil
 	}
 
 	// Currently using case implementation to avoid adding a dependency module or exposing

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -40,13 +40,28 @@ func HasRegex(input formula.Input) bool {
 	return len(input.Pattern.Regex) > 0
 }
 
-func VerifyConditional(cmd *exec.Cmd, input formula.Input) (bool, error) {
+
+func inputConditionVariableExistsOnInputList(variable string, inputList formula.Inputs) (bool) {
+	for _, inputListElement := range inputList {
+		if inputListElement.Name == variable {
+			return true
+		}
+	}
+	return false
+}
+
+func VerifyConditional(cmd *exec.Cmd, input formula.Input, inputList formula.Inputs) (bool, error) {
 	if input.Condition.Variable == "" {
 		return true, nil
 	}
 
-	var value string
 	variable := input.Condition.Variable
+
+	if !inputConditionVariableExistsOnInputList(variable, inputList) {
+		return false, fmt.Errorf("config.json: conditional variable %s not found", variable)
+	}
+
+	var value string
 	for _, envVal := range cmd.Env {
 		components := strings.Split(envVal, "=")
 		if strings.ToLower(components[0]) == variable {
@@ -54,8 +69,9 @@ func VerifyConditional(cmd *exec.Cmd, input formula.Input) (bool, error) {
 			break
 		}
 	}
+
 	if value == "" {
-		return false, fmt.Errorf("config.json: conditional variable %s not found", variable)
+		return true, nil
 	}
 
 	// Currently using case implementation to avoid adding a dependency module or exposing

--- a/pkg/formula/input/input.go
+++ b/pkg/formula/input/input.go
@@ -40,7 +40,7 @@ func HasRegex(input formula.Input) bool {
 	return len(input.Pattern.Regex) > 0
 }
 
-func inputConditionVariableExistsOnInputList(variable string, inputList formula.Inputs) (bool) {
+func inputConditionVariableExistsOnInputList(variable string, inputList formula.Inputs) bool {
 	for _, inputListElement := range inputList {
 		if inputListElement.Name == variable {
 			return true

--- a/pkg/formula/input/prompt/prompt.go
+++ b/pkg/formula/input/prompt/prompt.go
@@ -89,7 +89,7 @@ func (in InputManager) Inputs(cmd *exec.Cmd, setup formula.Setup, f *pflag.FlagS
 		if err != nil {
 			return err
 		}
-		conditionPass, err := input.VerifyConditional(cmd, i)
+		conditionPass, err := input.VerifyConditional(cmd, i, config.Inputs)
 		if err != nil {
 			return err
 		}

--- a/pkg/formula/input/prompt/prompt_test.go
+++ b/pkg/formula/input/prompt/prompt_test.go
@@ -274,6 +274,33 @@ func TestConditionalInputs(t *testing.T) {
 			"operator": "%s",
 			"value":    "in_list1"
 		}
+    },
+    {
+        "name": "sample_bool",
+        "type": "bool",
+        "default": "false",
+        "items": [
+            "false",
+            "true"
+        ],
+		"condition": {
+			"variable": "sample_list",
+			"operator": "==",
+			"value":    "in_list2"
+		},
+        "label": "Pick: ",
+		"tutorial": "Select true or false for this field."
+    },
+    {
+        "name": "sample_password",
+        "type": "password",
+		"condition": {
+			"variable": "sample_bool",
+			"operator": "==",
+			"value":    "true"
+		},
+        "label": "Pick: ",
+		"tutorial": "Add a secret password for this field."
     }
 ]`
 
@@ -366,9 +393,9 @@ func TestConditionalInputs(t *testing.T) {
 			}
 
 			iTextDefault := &mocks.InputDefaultTextMock{}
-			iTextDefault.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("default value", nil)
+			iTextDefault.On("Text", mock.Anything, mock.Anything, mock.Anything).Return("default", nil)
 			iList := &mocks.InputListMock{}
-			iList.On("List", mock.Anything, mock.Anything, mock.Anything).Return("list value", nil)
+			iList.On("List", mock.Anything, mock.Anything, mock.Anything).Return("in_list1", nil)
 
 			inputManager := NewInputManager(
 				&mocks.CredResolverMock{},


### PR DESCRIPTION

Signed-off-by: Finzi <andressa.abreu@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
Formulas with nested conditional inputs were returning an unnecessary error.
When there were two flows of nested conditionals, for example, consequently one of them was not satisfied. But an error was returned when the variables of the alternative flow conditionals were tested.  The error said that such variables did not exist, however, they existed. They just weren't being filled by belonging to that other flow that didn't happen.

### How to verify it
Test nested conditional inputs with a alternative flow. (Not a error)
Test conditional inputs that not exists. (A error)

### Changelog
Changing conditional  to only return an error when the conditional input variable does not exist in the config.json variable list
