### PR TITLE
Correction of input flags with parameter not required.

### DIFF
--- a/pkg/formula/input/flag/flag.go
+++ b/pkg/formula/input/flag/flag.go
@@ -101,7 +101,7 @@ func (in InputManager) Inputs(cmd *exec.Cmd, setup formula.Setup, flags *pflag.F
 		}
 	}
 
-	if len(emptyInputs) > 0 {
+	if len(emptyFlags) > 0 {
 		return fmt.Errorf("these flags cannot be empty [%s]", strings.Join(emptyFlags, ", "))
 	}
 


### PR DESCRIPTION
Signed-off-by: Fabiano Chiareto Fernandes <fabiano.fernandes@zup.com.br>

### Description
Correction of input flags with parameter not required.

### How to verify it

Run a formula with input not required and do not enter the parameter via input flags and use --default=true. The CLI will give the following error message.

![image](https://user-images.githubusercontent.com/58859234/111516920-3f4c9f00-8733-11eb-94be-7da8f07e2878.png)

### Changelog

- Correction of input flags with parameter not required.
