### PR TITLE
Friendlier error message on update repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @kaduartur @victor-schumacher @victorschumacherzup @brunasilvazup @lucasdittrichzup @henriquemoraeszup @rodrigomedeirosf @ernelio
+*       @kaduartur @victor-schumacher @victorschumacherzup @brunasilvazup @lucasdittrichzup @henriquemoraeszup @rodrigomedeirosf @ernelio @fernandobelettizup

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @kaduartur @victor-schumacher @victorschumacherzup @brunasilvazup @lucasdittrichzup @henriquemoraeszup @rodrigomedeirosf @ernelio @fernandobelettizup
+*       @kaduartur @brunasilvazup @lucasdittrichzup @henriquemoraeszup @rodrigomedeirosf @ernelio @fernandobelettizup

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@
 
 Bruna Tavares <silvatavares.bruna@gmail.com>
 Ernélio Júnior <erneliojunior@gmail.com>
+Fernando Beletti <fernando.beletti@zup.com.br>
 Gabriel Pinheiro <gabrielctpinheiro@gmail.com>
 Guillaume Falourd <guillaume.falourd@zup.com.br>
 Harirai Mahajan <harim1709@gmail.com>

--- a/pkg/git/bitbucket/repository.go
+++ b/pkg/git/bitbucket/repository.go
@@ -28,12 +28,6 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
-var ErrRepoNotFound = errors.New(
-	`could not retrieve new versions for selected repository
-Please check if it still exists or changed visiblity
-Try adding it again using:
-rit add repo`)
-
 type RepoManager struct {
 	client *http.Client
 }
@@ -76,7 +70,7 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, ErrRepoNotFound
+		return git.Tags{}, git.ErrRepoNotFound
 	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))

--- a/pkg/git/bitbucket/repository.go
+++ b/pkg/git/bitbucket/repository.go
@@ -69,11 +69,8 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, git.ErrRepoNotFound
-	} else if res.StatusCode != http.StatusOK {
-		all, _ := ioutil.ReadAll(res.Body)
-		return git.Tags{}, errors.New(res.Status + "-" + string(all))
+	if err := git.CheckStatusCode(res); err != nil {
+		return git.Tags{}, err
 	}
 
 	var bTags bitbucketTags

--- a/pkg/git/bitbucket/repository.go
+++ b/pkg/git/bitbucket/repository.go
@@ -75,7 +75,7 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusForbidden {
+	if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusNotFound {
 		return git.Tags{}, ErrRepoNotFound
 	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)

--- a/pkg/git/bitbucket/repository.go
+++ b/pkg/git/bitbucket/repository.go
@@ -28,6 +28,12 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
+var ErrRepoNotFound = errors.New(
+	`could not retrieve new versions for selected repository
+Please check if it still exists or changed visiblity
+Try adding it again using:
+rit add repo`)
+
 type RepoManager struct {
 	client *http.Client
 }
@@ -69,7 +75,9 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode == http.StatusForbidden {
+		return git.Tags{}, ErrRepoNotFound
+	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))
 	}

--- a/pkg/git/bitbucket/repository_test.go
+++ b/pkg/git/bitbucket/repository_test.go
@@ -33,6 +33,12 @@ func TestTags(t *testing.T) {
 	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusBadRequest)
 	}))
+	mockServerNotFound := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	mockServerForbidden := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+	}))
 
 	tests := []struct {
 		name    string
@@ -73,6 +79,24 @@ func TestTags(t *testing.T) {
 			},
 			want:    git.Tags{},
 			wantErr: "Get \"\": unsupported protocol scheme \"\"",
+		},
+		{
+			name:   "Return err when repo not found",
+			client: mockServerNotFound.Client(),
+			info: info{
+				tagsUrl: mockServerNotFound.URL,
+			},
+			want:    git.Tags{},
+			wantErr: git.ErrRepoNotFound.Error(),
+		},
+		{
+			name:   "Return err when repo access denied",
+			client: mockServerForbidden.Client(),
+			info: info{
+				tagsUrl: mockServerForbidden.URL,
+			},
+			want:    git.Tags{},
+			wantErr: git.ErrRepoNotFound.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -15,7 +15,16 @@
  */
 package git
 
-import "io"
+import (
+	"errors"
+	"io"
+)
+
+var ErrRepoNotFound = errors.New(
+	`could not retrieve new versions for selected repository
+Please check if it still exists or changed visiblity
+Try adding it again using:
+rit add repo`)
 
 type Tag struct {
 	Name        string `json:"tag_name"`

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -18,6 +18,8 @@ package git
 import (
 	"errors"
 	"io"
+	"io/ioutil"
+	"net/http"
 )
 
 var ErrRepoNotFound = errors.New(
@@ -40,6 +42,17 @@ func (t Tags) Names() []string {
 	}
 
 	return tags
+}
+
+func CheckStatusCode(res *http.Response) (err error) {
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden {
+		return ErrRepoNotFound
+	} else if res.StatusCode != http.StatusOK {
+		all, _ := ioutil.ReadAll(res.Body)
+		return errors.New(res.Status + "-" + string(all))
+	}
+
+	return nil
 }
 
 type RepoInfo interface {

--- a/pkg/git/github/repository.go
+++ b/pkg/git/github/repository.go
@@ -28,12 +28,6 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
-var ErrRepoNotFound = errors.New(
-	`could not retrieve new versions for selected repository
-Please check if it still exists or changed visiblity
-Try adding it again using:
-rit add repo`)
-
 type RepoManager struct {
 	client *http.Client
 }
@@ -67,7 +61,7 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 	if res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, ErrRepoNotFound
+		return git.Tags{}, git.ErrRepoNotFound
 	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))

--- a/pkg/git/github/repository.go
+++ b/pkg/git/github/repository.go
@@ -60,11 +60,9 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	}
 
 	defer res.Body.Close()
-	if res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, git.ErrRepoNotFound
-	} else if res.StatusCode != http.StatusOK {
-		all, _ := ioutil.ReadAll(res.Body)
-		return git.Tags{}, errors.New(res.Status + "-" + string(all))
+
+	if err := git.CheckStatusCode(res); err != nil {
+		return git.Tags{}, err
 	}
 
 	var tags git.Tags

--- a/pkg/git/github/repository.go
+++ b/pkg/git/github/repository.go
@@ -28,6 +28,12 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
+var ErrRepoNotFound = errors.New(
+	`could not retrieve new versions for selected repository
+Please check if it still exists or changed visiblity
+Try adding it again using:
+rit add repo`)
+
 type RepoManager struct {
 	client *http.Client
 }
@@ -60,7 +66,9 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	}
 
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode == http.StatusNotFound {
+		return git.Tags{}, ErrRepoNotFound
+	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))
 	}

--- a/pkg/git/github/repository_test.go
+++ b/pkg/git/github/repository_test.go
@@ -34,6 +34,9 @@ func TestTags(t *testing.T) {
 	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusBadRequest)
 	}))
+	mockServerNotFound := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
 
 	tests := []struct {
 		name    string
@@ -73,6 +76,15 @@ func TestTags(t *testing.T) {
 			},
 			want:    git.Tags{},
 			wantErr: "Get \"htttp://yourhost.com/username/repo/\": unsupported protocol scheme \"htttp\"",
+		},
+		{
+			name:   "Return err when repo not found",
+			client: mockServerNotFound.Client(),
+			info: info{
+				tagsUrl: mockServerNotFound.URL,
+			},
+			want:    git.Tags{},
+			wantErr: git.ErrRepoNotFound.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/git/gitlab/repository.go
+++ b/pkg/git/gitlab/repository.go
@@ -60,11 +60,8 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, git.ErrRepoNotFound
-	} else if res.StatusCode != http.StatusOK {
-		all, _ := ioutil.ReadAll(res.Body)
-		return git.Tags{}, errors.New(res.Status + "-" + string(all))
+	if err := git.CheckStatusCode(res); err != nil {
+		return git.Tags{}, err
 	}
 
 	var tags git.Tags

--- a/pkg/git/gitlab/repository.go
+++ b/pkg/git/gitlab/repository.go
@@ -27,12 +27,6 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
-var ErrRepoNotFound = errors.New(
-	`could not retrieve new versions for selected repository
-Please check if it still exists or changed visiblity
-Try adding it again using:
-rit add repo`)
-
 type RepoManager struct {
 	client *http.Client
 }
@@ -67,7 +61,7 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusNotFound {
-		return git.Tags{}, ErrRepoNotFound
+		return git.Tags{}, git.ErrRepoNotFound
 	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))

--- a/pkg/git/gitlab/repository.go
+++ b/pkg/git/gitlab/repository.go
@@ -27,6 +27,12 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/http/headers"
 )
 
+var ErrRepoNotFound = errors.New(
+	`could not retrieve new versions for selected repository
+Please check if it still exists or changed visiblity
+Try adding it again using:
+rit add repo`)
+
 type RepoManager struct {
 	client *http.Client
 }
@@ -60,7 +66,9 @@ func (re RepoManager) Tags(info git.RepoInfo) (git.Tags, error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode == http.StatusNotFound {
+		return git.Tags{}, ErrRepoNotFound
+	} else if res.StatusCode != http.StatusOK {
 		all, _ := ioutil.ReadAll(res.Body)
 		return git.Tags{}, errors.New(res.Status + "-" + string(all))
 	}

--- a/pkg/git/gitlab/repository_test.go
+++ b/pkg/git/gitlab/repository_test.go
@@ -33,6 +33,9 @@ func TestTags(t *testing.T) {
 	mockServerThatFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusBadRequest)
 	}))
+	mockServerNotFound := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
 
 	tests := []struct {
 		name    string
@@ -73,6 +76,15 @@ func TestTags(t *testing.T) {
 			},
 			want:    git.Tags{},
 			wantErr: "Get \"htttp://yourhost.com/username/repo/\": unsupported protocol scheme \"htttp\"",
+		},
+		{
+			name:   "Return err when repo not found",
+			client: mockServerNotFound.Client(),
+			info: info{
+				tagsUrl: mockServerNotFound.URL,
+			},
+			want:    git.Tags{},
+			wantErr: git.ErrRepoNotFound.Error(),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
This pull request improves the error message when `update repo` breaks in case of repositories changing visibility or being deleted.

New error messages follows:
`Error: could not retrieve new versions for selected repository`
`Please check if it still exists or changed visiblity`
`Try adding it again using:`
`rit add repo`

![image](https://user-images.githubusercontent.com/60020008/114069462-65b6b380-9875-11eb-9b72-6a28f5806881.png)

Additionaly I'm adding @fernandobelettizup to code owners and contributors list.
### How to verify it
Steps:
1. Clone this PR;
2. Build rit;
3. Using `rit add repo` add a public formula repository;
4. Delete or change its visibility;
5. Try updating it with `rit update repo`

### Changelog
Friendlier error message on update repo
