### PR TITLE
Fixes ZupIT/ritchie-cli#914 by changing Docker's invocation command f…

### DIFF
--- a/pkg/formula/runner/docker/pre_run.go
+++ b/pkg/formula/runner/docker/pre_run.go
@@ -39,7 +39,7 @@ const (
 	loadConfigErrMsg = `Failed to load formula config file
 Try running rit update repo
 Config file path not found: %s`
-	dockerCmd = "docker"
+	dockerCmd = "com.docker.cli"
 )
 
 var (


### PR DESCRIPTION
### Description
Ritchie's Docker runner is totally broken on MacOS and Windows 10 with the latest Docker version (3.3.3). To fix it, we need to invoke the `com.docker.cli` binary/alias rather than `docker`.

### How to verify it
Run Formulas with the Docker runner on MacOS and Windows 10.

### Changelog

- Changes the invocation command from `docker `to `com.docker.cli`
