### PR TITLE
Fixes #914 by changing Docker's invocation command

### DIFF
--- a/pkg/formula/runner/docker/pre_run.go
+++ b/pkg/formula/runner/docker/pre_run.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -39,7 +40,6 @@ const (
 	loadConfigErrMsg = `Failed to load formula config file
 Try running rit update repo
 Config file path not found: %s`
-	dockerCmd = "docker"
 )
 
 var (
@@ -208,7 +208,7 @@ func buildRunImg(def formula.Definition) (string, error) {
 	containerId = strings.ToLower(containerId)
 	args := []string{"build", "-t", containerId, "."}
 	//nolint:gosec
-	cmd := exec.Command(dockerCmd, args...) // Run command "docker build -t (randomId) ."
+	cmd := exec.Command(getDockerCmd(), args...) // Run command "docker build -t (randomId) ."
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
@@ -223,7 +223,7 @@ func buildRunImg(def formula.Definition) (string, error) {
 // validate checks if able to run inside docker
 func validateDocker(dockerImg string) error {
 	args := []string{"version", "--format", "'{{.Server.Version}}'"}
-	cmd := exec.Command(dockerCmd, args...)
+	cmd := exec.Command(getDockerCmd(), args...)
 	output, err := cmd.CombinedOutput()
 	if output == nil || err != nil {
 		return ErrDockerNotInstalled
@@ -244,4 +244,12 @@ func validateVolumes(dockerVolumes []string) error {
 		}
 	}
 	return nil
+}
+
+func getDockerCmd() string {
+	if runtime.GOOS == "linux" {
+		return "docker"
+	} else {
+		return "com.docker.cli"
+	}
 }

--- a/pkg/formula/runner/docker/runner.go
+++ b/pkg/formula/runner/docker/runner.go
@@ -127,7 +127,7 @@ func (ru RunManager) runDocker(setup formula.Setup, inputType api.TermInputType,
 	)
 
 	//nolint:gosec,lll
-	cmd := exec.Command(dockerCmd, args...) // Run command "docker run -env-file .env -v "$(pwd):/app" --name (randomId) (randomId)"
+	cmd := exec.Command(getDockerCmd(), args...) // Run command "docker run -env-file .env -v "$(pwd):/app" --name (randomId) (randomId)"
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### Description
Ritchie's Docker runner is totally broken on MacOS and Windows 10 with the latest Docker version (3.3.3).

### How to verify it
Run Formulas with the Docker runner on MacOS and Windows 10.

### Changelog

- Changes the invocation command from 'docker' to 'com.docker.cli' when the runtime env is Windows or MacOS.
