### PR TITLE
Update CHANGELOG.md with Release Patch 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.11.1](https://github.com/zupit/ritchie-cli/tree/2.11.1) (2021-05-14)
+
+[Full Changelog](https://github.com/zupit/ritchie-cli/compare/2.11.0...2.11.1)
+
+**Closed issues:**
+
+- exec: "com.docker.cli": executable file not found in $PATH [\#914](https://github.com/ZupIT/ritchie-cli/issues/914)
+
+**Merged pull requests:**
+
+- Fixes #914 by changing Docker's invocation command [\#925](https://github.com/ZupIT/ritchie-cli/pull/925) ([dcominottim](https://github.com/dcominottim))
+
 ## [2.11.0](https://github.com/zupit/ritchie-cli/tree/2.11.0) (2021-05-04)
 
 [Full Changelog](https://github.com/zupit/ritchie-cli/compare/2.10.3...2.11.0)


### PR DESCRIPTION
## What happened

- The new release update to the changelog file wasn't generated automatically.

## Why is it necessary

- To keep implementation history of what has been done.