### PR TITLE
Add `Generate Patch Tag` workflow on Github Actions

### DIFF
--- a/.github/workflows/generate-patch-tag.yml
+++ b/.github/workflows/generate-patch-tag.yml
@@ -1,0 +1,35 @@
+name: Generate Patch Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      reference-tag:
+        description: 'Tag from which we want to create the patch (ex: v1.2.3)'
+        required: true
+      new-tag:
+        description: 'New tag that will be created (ex: v1.2.4)'
+        required: true
+      commit-hash:
+        description: 'Commit Hash to add to the reference tag to generate the new tag' # e.g: abc123ce79159e628371a06d3b7e0d757abc123
+        required: true
+
+jobs:
+  generate-patch-tag:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.ACCESS_TOKEN }}
+      
+      - name: Execute Cherry Pick commands
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch -a
+          git checkout tags/${{ github.event.inputs.reference-tag }} -b release-${{ github.event.inputs.new-tag }}
+          git cherry-pick ${{ github.event.inputs.commit-hash }}
+          git tag ${{ github.event.inputs.new-tag }}
+          git push --tags

--- a/.github/workflows/generate-patch-tag.yml
+++ b/.github/workflows/generate-patch-tag.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       reference-tag:
-        description: 'Tag from which we want to create the patch (ex: v1.2.3)'
+        description: 'Tag from which we want to create the patch (e.g: 1.2.3)'
         required: true
       new-tag:
-        description: 'New tag that will be created (ex: v1.2.4)'
+        description: 'New tag that will be created (e.g: 1.2.4)'
         required: true
       commit-hash:
         description: 'Commit Hash to add to the reference tag to generate the new tag' # e.g: abc123ce79159e628371a06d3b7e0d757abc123


### PR DESCRIPTION
### Description

- Workflow to make it easier to generate Ritchie CLI patch when necessary.

### Demonstration

- Using [this workflow implementation](https://github.com/GuillaumeFalourd/poc-github-actions/blob/main/.github/workflows/test-cherry-pick.yml)
- Running the workflow manually with inputs has shown below:

![Screen Shot 2021-05-19 at 12 03 37](https://user-images.githubusercontent.com/22433243/118836503-46f70400-b89a-11eb-9e09-211366ce9b89.png)

- Will provide [this kind of output](https://github.com/GuillaumeFalourd/poc-github-actions/actions/runs/854531334)

### How to verify it

- Use the workflow on any repository following the demonstration steps above.

### Changelog

- Add `Generate Patch Tag` workflow (Github Actions).

### Pending

- To make this workflow works, it will be necessary to add a `ACCESS_TOKEN` secrets with *workflows* permissions to the repository.