### PR TITLE
Add `Open Issue Doc` workflow on Github Actions

### DIFF
--- a/.github/workflows/open-issue-doc.yml
+++ b/.github/workflows/open-issue-doc.yml
@@ -1,0 +1,20 @@
+name: Open Issue Doc
+
+on:
+  issues: 
+    types: [opened, labeled]
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Open new ISSUE on ZupIT/docs-ritchie repository
+      if: contains(github.event.label.name , 'documentation')
+      uses: GuillaumeFalourd/open-issue-action@main
+      with:
+        access-token: ${{ secrets.ACCESS_TOKEN }}
+        repo-owner: ZupIT
+        repo-name: docs-ritchie
+        issue-title: ${{ github.event.issue.title }}
+        issue-body: New ISSUE referring to ${{ github.event.issue.html_url }} opened from https://github.com/ZupIT/ritchie-cli/issues through the open-issue-action.

--- a/.github/workflows/open-issue-doc.yml
+++ b/.github/workflows/open-issue-doc.yml
@@ -11,7 +11,7 @@ jobs:
 
     - name: Open new ISSUE on ZupIT/docs-ritchie repository
       if: contains(github.event.label.name , 'documentation')
-      uses: GuillaumeFalourd/open-issue-action@main
+      uses: GuillaumeFalourd/open-issue-action@v1
       with:
         access-token: ${{ secrets.ACCESS_TOKEN }}
         repo-owner: ZupIT


### PR DESCRIPTION
### Description

- This workflow will automatically add a new issue on the [docs-ritchie](https://github.com/ZupIT/docs-ritchie/issues) repository if an issue is opened or labeled on this repository (ritchie-cli) with the `documentation` label.

Reference: [open issue action](https://github.com/GuillaumeFalourd/open-issue-action)

### How to verify it

- Create a new issue with the `documentation` label.

### Changelog

- Add `Open Issue Doc` workflow (Github Actions).

### Pending

- To make this workflow works, it will be necessary to add a `ACCESS_TOKEN` secrets to the repository which have *collaborator* and *repo* permissions and access to both repositories.