### PR TITLE
Update metrics for input flags

### DIFF
--- a/pkg/metric/data_collector.go
+++ b/pkg/metric/data_collector.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ var (
 	_                Collector = DataCollectorManager{}
 	CommonsRepoAdded           = ""
 	RepoName                   = ""
+	regexFlag                  = regexp.MustCompile(`--docker|--local|--stdin|--version|--verbose|--default|--help`)
 )
 
 type DataCollectorManager struct {
@@ -101,5 +103,11 @@ func (d DataCollectorManager) repoData() formula.Repo {
 func metricID() string {
 	args := os.Args
 	args[0] = "rit"
-	return strings.Join(args, "_")
+	var metricID []string
+	for _, element := range args {
+		if !strings.Contains(element, "--") || regexFlag.MatchString(element) {
+			metricID = append(metricID, element)
+		}
+	}
+	return strings.Join(metricID, "_")
 }

--- a/pkg/metric/data_collector.go
+++ b/pkg/metric/data_collector.go
@@ -35,7 +35,7 @@ var (
 	CommonsRepoAdded           = ""
 	RepoName                   = ""
 	regexCoreFlag              = regexp.MustCompile(`--docker|--local|--stdin|--version|--verbose|--default|--help`)
-	regexFlag                  = regexp.MustCompile("--(.*)=")
+	//regexFlag                  = regexp.MustCompile("--(.*)=")
 )
 
 type DataCollectorManager struct {

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -57,6 +57,7 @@ type Data struct {
 	CommandExecutionTime float64      `json:"commandExecutionTime"`
 	MetricsAcceptance    string       `json:"metricsAcceptance,omitempty"`
 	FormulaRepo          formula.Repo `json:"repo,omitempty"`
+	Flags                []string     `json:"flags,omitempty"`
 }
 
 type Sender interface {


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

Closes: https://github.com/ZupIT/ritchie-cli/issues/919

### Description

- Update metrics treatment for input flags

#### How?

- Keeping core commands on the `metricId`, such as: `rit_add_repo`
- Keeping *only* core flags on `data` interface, such as `data["flags"]=["docker", "help"]`
- Not keeping any formula input flag key (the code has been commented to make it possible if necessary in the future).

### How to verify it

- Accessing database

### Changelog

- Update metrics treatment for input flags