### PR TITLE
support flags - rit init

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -57,7 +58,31 @@ var (
 	errMsg                    = prompt.Yellow(i18n.T("init.add.commons.repo.error"))
 	ErrInitCommonsRepo        = errors.New(errMsg)
 	ErrInvalidRunType         = errors.New(i18n.T("init.invalid.run.type.error", strings.Join(formula.RunnerTypes, ", ")))
+	metricsFlag               = "sendmetrics"
+	commonsFlag               = "downcommons"
+	runnerFlag                = "runner"
 )
+
+var initFlags = flags{
+	{
+		name:        metricsFlag,
+		kind:        reflect.String,
+		defValue:    "yes",
+		description: "Send metrics",
+	},
+	{
+		name:        commonsFlag,
+		kind:        reflect.String,
+		defValue:    "yes",
+		description: "Download commons",
+	},
+	{
+		name:        runnerFlag,
+		kind:        reflect.String,
+		defValue:    "yes",
+		description: "Set runner type",
+	},
+}
 
 type initStdin struct {
 	AddCommons  bool   `json:"addCommons"`
@@ -402,4 +427,31 @@ func (in initCmd) warning() {
 func (in initCmd) initSuccess() {
 	success := i18n.T("init.successful")
 	prompt.Success(success)
+}
+
+func (in *initCmd) resolveFlags(cmd *cobra.Command) error {
+	metrics, err := cmd.Flags().GetString(metricsFlag)
+	if err != nil {
+		return err
+	}
+	common, err := cmd.Flags().GetString(commonsFlag)
+	if err != nil {
+		return err
+	}
+	runner, err := cmd.Flags().GetString(runnerFlag)
+	if err != nil {
+		return err
+	}
+
+	if metrics == "" {
+		return errors.New(missingFlagText(metricsFlag))
+	} else if common == "" {
+		return errors.New(missingFlagText(commonsFlag))
+	} else if runner == "" {
+		return errors.New(missingFlagText(runnerFlag))
+	}
+
+
+
+	return nil
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -138,32 +138,6 @@ func NewInitCmd(
 	return cmd
 }
 
-func (in initCmd) runPrompt() (config.Configs, error) {
-
-	metrics, err := in.metricsAuthorization()
-	if err != nil {
-		return config.Configs{}, err
-	}
-
-	if err := in.addCommonsRepo(); err != nil {
-		return config.Configs{}, err
-	}
-
-	runType, err := in.setRunnerType()
-	if err != nil {
-		return config.Configs{}, err
-	}
-
-	configs := config.Configs{
-		Language: config.DefaultLang,
-		Metrics:  metrics,
-		RunType:  runType,
-		Tutorial: tutorialStatusEnabled,
-	}
-
-	return configs, nil
-}
-
 func (in initCmd) runStdin() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		init := initStdin{}
@@ -253,6 +227,148 @@ func (in initCmd) runStdin() CommandRunnerFunc {
 
 		return nil
 	}
+}
+
+func (in initCmd) runCmd() CommandRunnerFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		in.welcome()
+
+		configs, err := in.resolveInput(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := in.ritConfig.Write(configs); err != nil {
+			return err
+		}
+
+		in.initSuccess()
+
+		if err := in.tutorialInit(); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func (in initCmd) resolveInput(cmd *cobra.Command) (config.Configs, error) {
+	if IsFlagInput(cmd) {
+		return in.runFlags(cmd)
+	}
+	return in.runPrompt()
+}
+
+func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
+	metrics, err := cmd.Flags().GetString(metricsFlag)
+	if err != nil {
+		return config.Configs{}, err
+	}
+	common, err := cmd.Flags().GetString(commonsFlag)
+	if err != nil {
+		return config.Configs{}, err
+	}
+	runner, err := cmd.Flags().GetString(runnerFlag)
+	if err != nil {
+		return config.Configs{}, err
+	}
+
+	if metrics == "" {
+		return config.Configs{}, errors.New(missingFlagText(metricsFlag))
+	} else if common == "" {
+		return config.Configs{}, errors.New(missingFlagText(commonsFlag))
+	} else if runner == "" {
+		return config.Configs{}, errors.New(missingFlagText(runnerFlag))
+	}
+
+	if metrics == "no" {
+		in.metricSender.Send(metric.APIData{
+			Id:        "rit_init",
+			UserId:    "",
+			Timestamp: time.Now(),
+			Data: metric.Data{
+				MetricsAcceptance: metrics,
+			},
+		})
+	} else if metrics == "yes" {
+		if err = in.file.Write(metric.FilePath, []byte(metrics)); err != nil {
+			return config.Configs{}, err
+		}
+	} else {
+		return config.Configs{}, errors.New("please provide a valid value to the flag 'sendmetrics'")
+	}
+
+	if common == "no" {
+		in.commonsWarning()
+		metric.CommonsRepoAdded = "no"
+	} else if common == "yes" {
+		repo := formula.Repo{
+			Provider: "Github",
+			Name:     "commons",
+			Url:      CommonsRepoURL,
+			Priority: 0,
+		}
+		s := spinner.StartNew(i18n.T("init.adding.commons.repo"))
+		repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
+		tag, err := in.git.LatestTag(repoInfo)
+		if err != nil {
+			s.Error(ErrInitCommonsRepo)
+			fmt.Println(addRepoMsg)
+			return config.Configs{}, err
+		}
+		repo.Version = formula.RepoVersion(tag.Name)
+		if err := in.repo.Add(repo); err != nil {
+			s.Error(ErrInitCommonsRepo)
+			fmt.Println(addRepoMsg)
+			return config.Configs{}, err
+		}
+		in.commonsSuccess(s)
+	} else {
+		return config.Configs{}, errors.New("please provide a valid value to the flag 'addcommons'")
+	}
+
+	runType := formula.DefaultRun
+	for i := range formula.RunnerTypes {
+		if RunTypes[i] == runner {
+			runType = formula.RunnerType(i)
+			break
+		}
+	}
+
+	// Config Constructor
+	configs := config.Configs{
+		Language: config.DefaultLang,
+		Metrics:  metrics,
+		RunType:  runType,
+		Tutorial: tutorialStatusEnabled,
+	}
+
+	return configs, nil
+}
+
+func (in initCmd) runPrompt() (config.Configs, error) {
+
+	metrics, err := in.metricsAuthorization()
+	if err != nil {
+		return config.Configs{}, err
+	}
+
+	if err := in.addCommonsRepo(); err != nil {
+		return config.Configs{}, err
+	}
+
+	runType, err := in.setRunnerType()
+	if err != nil {
+		return config.Configs{}, err
+	}
+
+	configs := config.Configs{
+		Language: config.DefaultLang,
+		Metrics:  metrics,
+		RunType:  runType,
+		Tutorial: tutorialStatusEnabled,
+	}
+
+	return configs, nil
 }
 
 func (in initCmd) metricsAuthorization() (string, error) {
@@ -414,120 +530,4 @@ func (in initCmd) warning() {
 func (in initCmd) initSuccess() {
 	success := i18n.T("init.successful")
 	prompt.Success(success)
-}
-
-func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
-	metrics, err := cmd.Flags().GetString(metricsFlag)
-	if err != nil {
-		return config.Configs{}, err
-	}
-	common, err := cmd.Flags().GetString(commonsFlag)
-	if err != nil {
-		return config.Configs{}, err
-	}
-	runner, err := cmd.Flags().GetString(runnerFlag)
-	if err != nil {
-		return config.Configs{}, err
-	}
-
-	if metrics == "" {
-		return config.Configs{}, errors.New(missingFlagText(metricsFlag))
-	} else if common == "" {
-		return config.Configs{}, errors.New(missingFlagText(commonsFlag))
-	} else if runner == "" {
-		return config.Configs{}, errors.New(missingFlagText(runnerFlag))
-	}
-
-	if metrics == "no" {
-		in.metricSender.Send(metric.APIData{
-			Id:        "rit_init",
-			UserId:    "",
-			Timestamp: time.Now(),
-			Data: metric.Data{
-				MetricsAcceptance: metrics,
-			},
-		})
-	} else if metrics == "yes" {
-		if err = in.file.Write(metric.FilePath, []byte(metrics)); err != nil {
-			return config.Configs{}, err
-		}
-	} else {
-		return config.Configs{}, errors.New("please provide a valid value to the flag 'sendmetrics'")
-	}
-
-	if common == "no" {
-		in.commonsWarning()
-		metric.CommonsRepoAdded = "no"
-	} else if common == "yes" {
-		repo := formula.Repo{
-			Provider: "Github",
-			Name:     "commons",
-			Url:      CommonsRepoURL,
-			Priority: 0,
-		}
-		s := spinner.StartNew(i18n.T("init.adding.commons.repo"))
-		repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
-		tag, err := in.git.LatestTag(repoInfo)
-		if err != nil {
-			s.Error(ErrInitCommonsRepo)
-			fmt.Println(addRepoMsg)
-			return config.Configs{}, err
-		}
-		repo.Version = formula.RepoVersion(tag.Name)
-		if err := in.repo.Add(repo); err != nil {
-			s.Error(ErrInitCommonsRepo)
-			fmt.Println(addRepoMsg)
-			return config.Configs{}, err
-		}
-		in.commonsSuccess(s)
-	} else {
-		return config.Configs{}, errors.New("please provide a valid value to the flag 'addcommons'")
-	}
-
-	runType := formula.DefaultRun
-	for i := range formula.RunnerTypes {
-		if RunTypes[i] == runner {
-			runType = formula.RunnerType(i)
-			break
-		}
-	}
-
-	// Config Constructor
-	configs := config.Configs{
-		Language: config.DefaultLang,
-		Metrics:  metrics,
-		RunType:  runType,
-		Tutorial: tutorialStatusEnabled,
-	}
-
-	return configs, nil
-}
-
-func (in initCmd) resolveInput(cmd *cobra.Command) (config.Configs, error) {
-	if IsFlagInput(cmd) {
-		return in.runFlags(cmd)
-	}
-	return in.runPrompt()
-}
-
-func (in initCmd) runCmd() CommandRunnerFunc {
-	return func(cmd *cobra.Command, args []string) error {
-		in.welcome()
-
-		configs, err := in.resolveInput(cmd)
-		if err != nil {
-			return err
-		}
-
-		if err := in.ritConfig.Write(configs); err != nil {
-			return err
-		}
-
-		in.initSuccess()
-
-		if err := in.tutorialInit(); err != nil {
-			return err
-		}
-		return nil
-	}
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -61,6 +61,7 @@ var (
 	metricsFlag               = "sendMetrics"
 	commonsFlag               = "addCommons"
 	runnerFlag                = "runType"
+	provideValidValue         = "provide a valid value to the flag %q"
 )
 
 var initFlags = flags{
@@ -298,7 +299,7 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 		}
 	default:
 		{
-			return config.Configs{}, errors.New("please provide a valid value to the flag 'sendmetrics'")
+			return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, metricsFlag))
 		}
 
 	}
@@ -333,15 +334,16 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 			in.commonsSuccess(s)
 		}
 	default:
-		return config.Configs{}, errors.New("please provide a valid value to the flag 'addCommons'")
+		return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, commonsFlag))
 	}
 
 	runType := formula.DefaultRun
-	for i := range formula.RunnerTypes {
-		if RunTypes[i] == runner {
-			runType = formula.RunnerType(i)
-			break
-		}
+	if runner == "local" {
+		runType = formula.LocalRun
+	} else if runner == "docker" {
+		runType = formula.DockerRun
+	} else {
+		return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, runnerFlag))
 	}
 
 	configs := config.Configs{

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -277,11 +277,11 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 		return config.Configs{}, errors.New(missingFlagText(runnerFlag))
 	}
 
-	metricBool, err := flagToBool(metrics, metricsFlag)
+	metricBool, err := in.flagToBool(metrics, metricsFlag)
 	if err != nil {
 		return config.Configs{}, err
 	}
-	commonsBool, err := flagToBool(commons, commonsFlag)
+	commonsBool, err := in.flagToBool(commons, commonsFlag)
 	if err != nil {
 		return config.Configs{}, err
 	}
@@ -545,18 +545,8 @@ func (in initCmd) initSuccess() {
 	prompt.Success(success)
 }
 
-func flagToBool(f string, fn string) (bool, error) {
-	boolOpts := map[string]bool{
-		"yes":   true,
-		"no":    false,
-		"true":  true,
-		"false": false,
-		"Yes":   true,
-		"No":    false,
-		"True":  true,
-		"False": false,
-	}
-	if result, found := boolOpts[f]; found {
+func (in initCmd) flagToBool(f string, fn string) (bool, error) {
+	if result, found := prompt.BoolOpts[f]; found {
 		return result, nil
 	} else {
 		return false, fmt.Errorf(provideValidValue, fn)

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -345,7 +345,6 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 	case "docker":
 		runType = formula.DockerRun
 	default:
-		runType = formula.DefaultRun
 		return config.Configs{}, fmt.Errorf(provideValidValue, runnerFlag)
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -338,11 +338,14 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 		}
 	}
 
-	runType := formula.DefaultRun
+	var runType formula.RunnerType
 	switch runner {
-	case "local": runType = formula.LocalRun
-	case "docker": runType = formula.DockerRun
+	case "local":
+		runType = formula.LocalRun
+	case "docker":
+		runType = formula.DockerRun
 	default:
+		runType = formula.DefaultRun
 		return config.Configs{}, fmt.Errorf(provideValidValue, runnerFlag)
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -58,9 +58,9 @@ var (
 	errMsg                    = prompt.Yellow(i18n.T("init.add.commons.repo.error"))
 	ErrInitCommonsRepo        = errors.New(errMsg)
 	ErrInvalidRunType         = errors.New(i18n.T("init.invalid.run.type.error", strings.Join(formula.RunnerTypes, ", ")))
-	metricsFlag               = "sendmetrics"
-	commonsFlag               = "downcommons"
-	runnerFlag                = "runner"
+	metricsFlag               = "sendMetrics"
+	commonsFlag               = "addCommons"
+	runnerFlag                = "runType"
 )
 
 var initFlags = flags{
@@ -437,24 +437,62 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 	} else if runner == "" {
 		return config.Configs{}, errors.New(missingFlagText(runnerFlag))
 	}
-	// Send Metrics
 
-
-	// Download  Commons
-	if common == "yes" {
-		if err := in.addCommonsRepo(); err != nil {
+	if metrics == "no" {
+		in.metricSender.Send(metric.APIData{
+			Id:        "rit_init",
+			UserId:    "",
+			Timestamp: time.Now(),
+			Data: metric.Data{
+				MetricsAcceptance: metrics,
+			},
+		})
+	} else if metrics == "yes" {
+		if err = in.file.Write(metric.FilePath, []byte(metrics)); err != nil {
 			return config.Configs{}, err
 		}
+	} else {
+		return config.Configs{}, errors.New("please provide a valid value to the flag 'sendmetrics'")
 	}
 
-	// Set Runnertype
-	var runType formula.RunnerType
-	for i, v := range formula.RunnerTypes {
-		if v == runner {
+	if common == "no" {
+		in.commonsWarning()
+		metric.CommonsRepoAdded = "no"
+	} else if common == "yes" {
+		repo := formula.Repo{
+			Provider: "Github",
+			Name:     "commons",
+			Url:      CommonsRepoURL,
+			Priority: 0,
+		}
+		s := spinner.StartNew(i18n.T("init.adding.commons.repo"))
+		repoInfo := github.NewRepoInfo(repo.Url, repo.Token)
+		tag, err := in.git.LatestTag(repoInfo)
+		if err != nil {
+			s.Error(ErrInitCommonsRepo)
+			fmt.Println(addRepoMsg)
+			return config.Configs{}, err
+		}
+		repo.Version = formula.RepoVersion(tag.Name)
+		if err := in.repo.Add(repo); err != nil {
+			s.Error(ErrInitCommonsRepo)
+			fmt.Println(addRepoMsg)
+			return config.Configs{}, err
+		}
+		in.commonsSuccess(s)
+	} else {
+		return config.Configs{}, errors.New("please provide a valid value to the flag 'addcommons'")
+	}
+
+	runType := formula.DefaultRun
+	for i := range formula.RunnerTypes {
+		if RunTypes[i] == runner {
 			runType = formula.RunnerType(i)
+			break
 		}
 	}
 
+	// Config Constructor
 	configs := config.Configs{
 		Language: config.DefaultLang,
 		Metrics:  metrics,

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -299,7 +299,7 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 		}
 	default:
 		{
-			return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, metricsFlag))
+			return config.Configs{}, fmt.Errorf(provideValidValue, metricsFlag)
 		}
 
 	}
@@ -334,7 +334,7 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 			in.commonsSuccess(s)
 		}
 	default:
-		return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, commonsFlag))
+		return config.Configs{}, fmt.Errorf(provideValidValue, commonsFlag)
 	}
 
 	runType := formula.DefaultRun
@@ -343,7 +343,7 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 	} else if runner == "docker" {
 		runType = formula.DockerRun
 	} else {
-		return config.Configs{}, errors.New(fmt.Sprintf(provideValidValue, runnerFlag))
+		return config.Configs{}, fmt.Errorf(provideValidValue, runnerFlag)
 	}
 
 	configs := config.Configs{

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -105,7 +105,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				inList:         LocalRunType,
 			},
 			inputStdin: "{\"addCommons\": true, \"sendMetrics\": false, \"runType\": \"local\"}\n",
-			inputFlag: []string{"--sendMetrics=yes", "--addCommons=yes", "--runType=local"},
+			inputFlag:  []string{"--sendMetrics=yes", "--addCommons=yes", "--runType=local"},
 		},
 		{
 			name: "find tutorial error",
@@ -222,12 +222,11 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 		{
 			name: "error with flags, invalid metrics value",
 			in: in{
-				fileWriteErr:   errors.New("please provide a valid value to the flag 'sendmetrics'"),
-				inList:         LocalRunType,
-
+				fileWriteErr: errors.New("please provide a valid value to the flag 'sendmetrics'"),
+				inList:       LocalRunType,
 			},
 			inputFlag: []string{"--sendMetrics=invalidValue", "--addCommons=no", "--runType=local"},
-			wantErr: errors.New("please provide a valid value to the flag 'sendmetrics'"),
+			wantErr:   errors.New("please provide a valid value to the flag 'sendmetrics'"),
 		},
 		{
 			name: "error with flags, invalid commons value",
@@ -235,7 +234,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				fileWriteErr: errors.New("please provide a valid value to the flag 'addCommons'"),
 			},
 			inputFlag: []string{"--sendMetrics=no", "--addCommons=invalidValue", "--runType=local"},
-			wantErr: errors.New("please provide a valid value to the flag 'addCommons'"),
+			wantErr:   errors.New("please provide a valid value to the flag 'addCommons'"),
 		},
 		{
 			name: "error with flags, error to write metric file",
@@ -245,7 +244,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				fileWriteErr:   errors.New("error to write metric file"),
 			},
 			inputFlag: []string{"--sendMetrics=yes", "--addCommons=no", "--runType=local"},
-			wantErr: errors.New("error to write metric file"),
+			wantErr:   errors.New("error to write metric file"),
 		},
 		{
 			name: "error with flags, error to write metric file",
@@ -255,7 +254,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				fileWriteErr:   errors.New("error to write metric file"),
 			},
 			inputFlag: []string{"--sendMetrics=yes", "--addCommons=no", "--runType=local"},
-			wantErr: errors.New("error to write metric file"),
+			wantErr:   errors.New("error to write metric file"),
 		},
 	}
 

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -222,19 +222,19 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 		{
 			name: "error with flags, invalid metrics value",
 			in: in{
-				fileWriteErr: errors.New("please provide a valid value to the flag 'sendmetrics'"),
+				fileWriteErr: errors.New("provide a valid value to the flag \"sendMetrics\""),
 				inList:       LocalRunType,
 			},
 			inputFlag: []string{"--sendMetrics=invalidValue", "--addCommons=no", "--runType=local"},
-			wantErr:   errors.New("please provide a valid value to the flag 'sendmetrics'"),
+			wantErr:   errors.New("provide a valid value to the flag \"sendMetrics\""),
 		},
 		{
 			name: "error with flags, invalid commons value",
 			in: in{
-				fileWriteErr: errors.New("please provide a valid value to the flag 'addCommons'"),
+				fileWriteErr: errors.New("provide a valid value to the flag \"addCommons\""),
 			},
 			inputFlag: []string{"--sendMetrics=no", "--addCommons=invalidValue", "--runType=local"},
-			wantErr:   errors.New("please provide a valid value to the flag 'addCommons'"),
+			wantErr:   errors.New("provide a valid value to the flag \"addCommons\""),
 		},
 		{
 			name: "error with flags, error to write metric file",

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -57,6 +57,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 		in         in
 		wantErr    error
 		inputStdin string
+		inputFlag  []string
 	}{
 		{
 			name: "success to add commons repo and accept to send metrics",
@@ -104,6 +105,7 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				inList:         LocalRunType,
 			},
 			inputStdin: "{\"addCommons\": true, \"sendMetrics\": false, \"runType\": \"local\"}\n",
+			inputFlag: []string{"--sendMetrics=yes", "--addCommons=yes", "--runType=local"},
 		},
 		{
 			name: "find tutorial error",
@@ -199,6 +201,62 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 			wantErr:    errors.New("error to write ritchie configs"),
 			inputStdin: "{\"addCommons\": true,\"sendMetrics\": true, \"runType\": \"local\"}\n",
 		},
+		{
+			name: "success with flags, add commons and send metrics",
+			in: in{
+				gitTag:         git.Tag{Name: "1.0.0"},
+				tutorialHolder: rtutorial.TutorialHolder{Current: rtutorial.DefaultTutorial},
+				inList:         LocalRunType,
+			},
+			inputFlag: []string{"--sendMetrics=yes", "--addCommons=yes", "--runType=local"},
+		},
+		{
+			name: "success with flags, when not add commons and not send metrics",
+			in: in{
+				gitTag:         git.Tag{Name: "1.0.0"},
+				tutorialHolder: rtutorial.TutorialHolder{Current: rtutorial.DefaultTutorial},
+				inList:         LocalRunType,
+			},
+			inputFlag: []string{"--sendMetrics=no", "--addCommons=no", "--runType=docker"},
+		},
+		{
+			name: "error with flags, invalid metrics value",
+			in: in{
+				fileWriteErr:   errors.New("please provide a valid value to the flag 'sendmetrics'"),
+				inList:         LocalRunType,
+
+			},
+			inputFlag: []string{"--sendMetrics=invalidValue", "--addCommons=no", "--runType=local"},
+			wantErr: errors.New("please provide a valid value to the flag 'sendmetrics'"),
+		},
+		{
+			name: "error with flags, invalid commons value",
+			in: in{
+				fileWriteErr: errors.New("please provide a valid value to the flag 'addCommons'"),
+			},
+			inputFlag: []string{"--sendMetrics=no", "--addCommons=invalidValue", "--runType=local"},
+			wantErr: errors.New("please provide a valid value to the flag 'addCommons'"),
+		},
+		{
+			name: "error with flags, error to write metric file",
+			in: in{
+				gitTag:         git.Tag{Name: "1.0.0"},
+				tutorialHolder: rtutorial.TutorialHolder{Current: rtutorial.DefaultTutorial},
+				fileWriteErr:   errors.New("error to write metric file"),
+			},
+			inputFlag: []string{"--sendMetrics=yes", "--addCommons=no", "--runType=local"},
+			wantErr: errors.New("error to write metric file"),
+		},
+		{
+			name: "error with flags, error to write metric file",
+			in: in{
+				gitTag:         git.Tag{Name: "1.0.0"},
+				tutorialHolder: rtutorial.TutorialHolder{Current: rtutorial.DefaultTutorial},
+				fileWriteErr:   errors.New("error to write metric file"),
+			},
+			inputFlag: []string{"--sendMetrics=yes", "--addCommons=no", "--runType=local"},
+			wantErr: errors.New("error to write metric file"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,8 +309,22 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 				ritConfigMock,
 			)
 
+			initFlag := NewInitCmd(
+				repoMock,
+				gitMock,
+				tutorialMock,
+				configRunnerMock,
+				fileMock,
+				inListMock,
+				inBoolMock,
+				metricSender,
+				ritConfigMock,
+			)
+
 			initPrompt.PersistentFlags().Bool("stdin", false, "input by stdin")
 			initStdin.PersistentFlags().Bool("stdin", true, "input by stdin")
+			initFlag.PersistentFlags().Bool("stdin", false, "input by stdin")
+			initFlag.SetArgs(tt.inputFlag)
 
 			newReader := strings.NewReader(tt.inputStdin)
 			initStdin.SetIn(newReader)
@@ -263,6 +335,9 @@ func Test_initCmd_runAnyEntry(t *testing.T) {
 			if tt.inputStdin != "" {
 				gotStdin := initStdin.Execute()
 				assert.Equal(t, tt.wantErr, gotStdin)
+			} else if len(tt.inputFlag) != 0 {
+				gotFlag := initFlag.Execute()
+				assert.Equal(t, tt.wantErr, gotFlag)
 			}
 		})
 	}

--- a/pkg/prompt/bool.go
+++ b/pkg/prompt/bool.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	boolOpts = map[string]bool{
+	BoolOpts = map[string]bool{
 		"yes":   true,
 		"no":    false,
 		"true":  true,
@@ -56,5 +56,5 @@ func (SurveyBool) Bool(name string, items []string, helper ...string) (bool, err
 		return false, err
 	}
 
-	return boolOpts[choice], nil
+	return BoolOpts[choice], nil
 }


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
These changes are intended to improve the method of executing the `rit init` command. With them, the use of input flags will be allowed in the execution of the command.
### How to verify it
You can run the `rit init` command with the following flags:
`--sendMetrics=("yes", "no")` default: yes
`--addCommons=("yes", "no")` default: yes
`--runType=("local", "docker")` default: local
### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
