### PR TITLE
Github Action workflow to perform functional tests for `ENV` core commands using RIT binaries

### DIFF
--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -1,0 +1,31 @@
+name: Test Env Commands
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ubuntu:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            cd $GITHUB_WORKSPACE
+            make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
+            echo '{"addCommons":false, "sendMetrics":true, "runType":"local"}' | rit init --stdin
+        - name: RIT SHOW ENV command (1)
+          run:  |
+            rit show env > check1.txt
+            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+        - name: RIT SET ENV command
+          run: rit set env --env=test
+        - name: RIT SHOW ENV command (2)
+          run:  |
+            rit show env > check2.txt
+            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+        - name: RIT DELETE ENV command
+          run: rit delete env --env=test
+        - name: RIT SHOW ENV command (3)
+          run:  |
+            rit show env > check3.txt
+            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt

--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -1,7 +1,48 @@
 name: Test Env Commands
 
+# TXT files used for ASSERT are located on the /testdata/gha_workflows directory.
+
+# To help you coding your workflow tests, you can use CAT commands to show each file you will compare on the workflow window on Github.
+
+# EXAMPLE:
+#   rit show env > check1.txt
+#   cat check1.txt
+#   cat testdata/gha_workflows/env_workflow/assert1.txt
+#   diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Can be triggered manually through the ACTIONS tab on Github GUI.
+  push:
+    paths: # Will trigger on PUSH event that update at least one of those files.
+      - '**/cmd.go'
+      - '**/delete_test.go'
+      - '**/delete.go'
+      - '**/delete_env_test.go'
+      - '**/delete_env.go'
+      - '**/set_env_test.go'
+      - '**/set_env.go'
+      - '**/set_test.go'
+      - '**/set.go'
+      - '**/show_env_test.go'
+      - '**/show_env.go'
+      - '**/show_test.go'
+      - '**/show.go'
+
+  pull_request:
+    paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
+      - '**/cmd.go'
+      - '**/delete_test.go'
+      - '**/delete.go'
+      - '**/delete_env_test.go'
+      - '**/delete_env.go'
+      - '**/set_env_test.go'
+      - '**/set_env.go'
+      - '**/set_test.go'
+      - '**/set.go'
+      - '**/show_env_test.go'
+      - '**/show_env.go'
+      - '**/show_test.go'
+      - '**/show.go'
 
 jobs:
   ubuntu:

--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -29,3 +29,29 @@ jobs:
           run:  |
             rit show env > check3.txt
             diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt
+
+  macos:
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            cd $GITHUB_WORKSPACE
+            make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
+            echo '{"addCommons":false, "sendMetrics":true, "runType":"local"}' | rit init --stdin
+        - name: RIT SHOW ENV command (1)
+          run:  |
+            rit show env > check1.txt
+            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+        - name: RIT SET ENV command
+          run: rit set env --env=test
+        - name: RIT SHOW ENV command (2)
+          run:  |
+            rit show env > check2.txt
+            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+        - name: RIT DELETE ENV command
+          run: rit delete env --env=test
+        - name: RIT SHOW ENV command (3)
+          run:  |
+            rit show env > check3.txt
+            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt

--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -55,3 +55,30 @@ jobs:
           run:  |
             rit show env > check3.txt
             diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt
+
+  windows:
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            choco install make
+            make build-windows && move D:\a\ritchie-cli\ritchie-cli\dist\windows\rit.exe "D:\a\ritchie-cli\ritchie-cli"
+            ls
+            echo '{"addCommons":false, "sendMetrics":true, "runType":"local"}' | .\rit.exe init --stdin
+        - name: RIT SHOW ENV command (1)
+          run:  |
+            .\rit.exe show env > check1.txt
+            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+        - name: RIT SET ENV command
+          run: .\rit.exe set env --env=test
+        - name: RIT SHOW ENV command (2)
+          run:  |
+            .\rit.exe show env > check2.txt
+            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+        - name: RIT DELETE ENV command
+          run: .\rit.exe delete env --env=test
+        - name: RIT SHOW ENV command (3)
+          run:  |
+            .\rit.exe show env > check3.txt
+            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt

--- a/testdata/gha_workflows/env_workflow/assert1.txt
+++ b/testdata/gha_workflows/env_workflow/assert1.txt
@@ -1,0 +1,1 @@
+Current env: "default"

--- a/testdata/gha_workflows/env_workflow/assert2.txt
+++ b/testdata/gha_workflows/env_workflow/assert2.txt
@@ -1,0 +1,1 @@
+Current env: "test"


### PR DESCRIPTION
### Description

- Funcional tests using **rit** binaries for each OS, for the `env` core commands. Those kind of tests could improve the project quality and future pipeline performances by testing only what matters on each contribution, instead of testing everything every time.

- This workflow will trigger every time one of the paths informed files is updated, by a `PULL REQUEST` event or a `PUSH` event.

- The workflow executes in **parallel** jobs on `windows`, `ubuntu` and `macOS` where each job will:
    - use the make command to generate rit binary for the OS.
    - execute synchronously the following steps: `rit show env`, `rit set env`, `rit delete env`.
    - after each step, a check run is performed using `diff` command to assert the output is as expected.

- Expected outputs need to be added to the `/testdata/gha_workflows` directory, currently on the `.txt` format

#### Possible enhancements

- It is not possible to test **expected** error that way without breaking the job execution (which result in a workflow error). So it could be interesting to improve the way those functional tests are performed (through a script or a formula?) to be more assertive.

### How to verify it

- You can check the workflow execution on [this fork](https://github.com/GuillaumeFalourd/ritchie-cli/actions/workflows/test-env.yml)

Here are some samples:

![Screen Shot 2021-06-07 at 13 45 59](https://user-images.githubusercontent.com/22433243/121058445-b6279000-c796-11eb-8196-a40b9cbd0102.png)

![Screen Shot 2021-06-07 at 13 43 48](https://user-images.githubusercontent.com/22433243/121058341-a019cf80-c796-11eb-8c61-6d950b56afbe.png)

### Changelog

- Adding Github Action workflow performing funcional tests using **rit** binaries for each OS, for the `env` core commands.
 