### PR TITLE
Improve - Add workflows to build binary files when pull request is opened, and add links to pr body.

### DIFF
--- a/.github/workflows/build-binary-when-pr-open.yml
+++ b/.github/workflows/build-binary-when-pr-open.yml
@@ -1,0 +1,46 @@
+name: Build Binary Ritchie When PR Opens
+on: [pull_request]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Create binary from branch
+        run: |
+          cd $GITHUB_WORKSPACE
+          make build-linux
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: rit-linux
+          path: ./dist/linux/rit
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Create binary from branch
+        run: |
+          cd $GITHUB_WORKSPACE
+          make build-mac
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: rit-macos
+          path: ./dist/darwin/rit
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Create binary from branch
+        run: |
+          choco install make
+          make build-windows
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: rit-windows
+          path: D:\a\ritchie-cli\ritchie-cli\dist\windows\rit.exe

--- a/.github/workflows/list-artifacts-edit-pr-body.yml
+++ b/.github/workflows/list-artifacts-edit-pr-body.yml
@@ -1,0 +1,47 @@
+name: List Artifacts and Update Pull Request Body
+on:
+  workflow_run:
+    workflows: ["Build Binary Ritchie When PR Opens"]
+    types: [completed]
+
+jobs:
+  list-artifacts-edit-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List artifacts
+        id: list-artifacts
+        uses: chiaretto/github-action-list-artifacts-pr@master
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Update PR Body
+        uses: chiaretto/github-action-concat-pr-body@master
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: "
+        ### This pull request generated the following artifacts.
+
+  To test the health and quality of this implementation, download the respective binary
+  for your operating system, unzip and directly run the binary like the examples below.
+
+  - **Windows**\r
+  Download the file: **[rit-windows.zip](${{ steps.list-artifacts.outputs.rit-windows}})**\r
+  Unzip to some folder like: `C:\\home\\user\\downloads\\pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Access the folder: `cd C:\\home\\user\\downloads\\pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Directly call the binary: `.\\rit.exe --version` or `.\\rit.exe name of formula`\r
+  \r\r
+  - **Linux**\r
+  Download the file: **[rit-linux.zip](${{ steps.list-artifacts.outputs.rit-linux}})**\r
+  Unzip to some folder like: `/home/user/downloads/pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Access the folder: `cd /home/user/downloads/pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Assign execute permission to binary: `chmod +x ./rit`\r
+  Directly call the binary: `./rit --version` or `./rit.exe name of formula`\r
+  \r\r
+  - **MacOS**\r
+  Download the file: **[rit-macos.zip](${{ steps.list-artifacts.outputs.rit-macos}})**\r
+  Unzip to some folder like: `/home/user/downloads/pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Access the folder: `cd /home/user/downloads/pr${{ steps.pull-request-number.outputs.pull-request-number }}`\r
+  Assign execute permission to binary: `chmod +x ./rit`\r
+  Directly call the binary: `./rit --version` or `./rit.exe name of formula`\r
+        "
+          replace-last-message: true


### PR DESCRIPTION
Signed-off-by: fabianofernandeszup <fabiano.fernandes@zup.com.br>

### Description
Added workflows to build the ritchie binaries for this PR and add their download links to the pull request message body.

### How to verify it
After this PR is merged with the master, just open a pull request and the flow will run.

### Changelog
Does not interfere with the product, only the repository.
