### PR TITLE
Github Action workflow to perform functional tests for `GLOBAL` core commands using RIT binaries

### DIFF
--- a/.github/workflows/test-credential-commands.yml
+++ b/.github/workflows/test-credential-commands.yml
@@ -27,7 +27,7 @@ on:
       - '**/set_credential.go'
       - '**/set_test.go'
       - '**/set.go'
-
+      - 'testdata/gha_workflows/credential_workflow/**'
   pull_request:
     paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
       - '**/cmd.go'
@@ -43,6 +43,7 @@ on:
       - '**/set_credential.go'
       - '**/set_test.go'
       - '**/set.go'
+      - 'testdata/gha_workflows/credential_workflow/**'
 
 jobs:
   ubuntu:

--- a/.github/workflows/test-credential-commands.yml
+++ b/.github/workflows/test-credential-commands.yml
@@ -77,7 +77,7 @@ jobs:
         - uses: GuillaumeFalourd/diff-action@v1
           with:
             first_file_path: check3.txt
-            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
             expected_result: PASSED
 
   macos:
@@ -112,7 +112,7 @@ jobs:
         - uses: GuillaumeFalourd/diff-action@v1
           with:
             first_file_path: check3.txt
-            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
             expected_result: PASSED
 
   windows:
@@ -148,5 +148,5 @@ jobs:
         - uses: GuillaumeFalourd/diff-action@v1
           with:
             first_file_path: check3.txt
-            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
             expected_result: PASSED

--- a/.github/workflows/test-credential-commands.yml
+++ b/.github/workflows/test-credential-commands.yml
@@ -55,21 +55,30 @@ jobs:
             make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST CREDENTIAL command (1)
-          run:  |
-            rit list credential > check1.txt
-            diff check1.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: rit list credential > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET CREDENTIAL command
           run: rit set credential --provider=github --fields=username,email,token --values=test,test,test
         - name: RIT LIST CREDENTIAL command (2)
-          run:  |
-            rit list credential > check2.txt
-            diff check2.txt testdata/gha_workflows/credential_workflow/assert2.txt
+          run: rit list credential > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE CREDENTIAL command
           run: rit delete credential --provider=github
         - name: RIT LIST CREDENTIAL command (3)
-          run:  |
-            rit list credential > check3.txt
-            diff check3.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: rit list credential > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            expected_result: PASSED
 
   macos:
       runs-on: macos-latest
@@ -81,21 +90,30 @@ jobs:
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST CREDENTIAL command (1)
-          run:  |
-            rit list credential > check1.txt
-            diff check1.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: rit list credential > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET CREDENTIAL command
           run: rit set credential --provider=github --fields=username,email,token --values=test,test,test
         - name: RIT LIST CREDENTIAL command (2)
-          run:  |
-            rit list credential > check2.txt
-            diff check2.txt testdata/gha_workflows/credential_workflow/assert2.txt
+          run: rit list credential > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE CREDENTIAL command
           run: rit delete credential --provider=github
         - name: RIT LIST CREDENTIAL command (3)
-          run:  |
-            rit list credential > check3.txt
-            diff check3.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: rit list credential > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            expected_result: PASSED
 
   windows:
       runs-on: windows-latest
@@ -108,18 +126,27 @@ jobs:
             ls
             .\rit.exe init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST CREDENTIAL command (1)
-          run:  |
-            .\rit.exe list credential > check1.txt
-            diff check1.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: .\rit.exe list credential > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET CREDENTIAL command
           run: .\rit.exe set credential --provider=github --fields=username,email,token --values=test,test,test
         - name: RIT LIST CREDENTIAL command (2)
-          run:  |
-            .\rit.exe list credential > check2.txt
-            diff check2.txt testdata/gha_workflows/credential_workflow/assert2.txt
+          run: .\rit.exe list credential > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE CREDENTIAL command
           run: .\rit.exe delete credential --provider=github
         - name: RIT LIST CREDENTIAL command (3)
-          run:  |
-            .\rit.exe list credential > check3.txt
-            diff check3.txt testdata/gha_workflows/credential_workflow/assert1.txt
+          run: .\rit.exe list credential > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/credential_workflow/assert3.txt
+            expected_result: PASSED

--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -55,21 +55,30 @@ jobs:
             make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT SHOW ENV command (1)
-          run:  |
-            rit show env > check1.txt
-            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: rit show env > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET ENV command
           run: rit set env --env=test
         - name: RIT SHOW ENV command (2)
-          run:  |
-            rit show env > check2.txt
-            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+          run: rit show env > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE ENV command
           run: rit delete env --env=test
         - name: RIT SHOW ENV command (3)
-          run:  |
-            rit show env > check3.txt
-            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: rit show env > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED
 
   macos:
       runs-on: macos-latest
@@ -81,21 +90,30 @@ jobs:
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT SHOW ENV command (1)
-          run:  |
-            rit show env > check1.txt
-            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: rit show env > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET ENV command
           run: rit set env --env=test
         - name: RIT SHOW ENV command (2)
-          run:  |
-            rit show env > check2.txt
-            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+          run: rit show env > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE ENV command
           run: rit delete env --env=test
         - name: RIT SHOW ENV command (3)
-          run:  |
-            rit show env > check3.txt
-            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: rit show env > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED
 
   windows:
       runs-on: windows-latest
@@ -108,18 +126,27 @@ jobs:
             ls
             .\rit.exe init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT SHOW ENV command (1)
-          run:  |
-            .\rit.exe show env > check1.txt
-            diff check1.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: .\rit.exe show env > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT SET ENV command
           run: .\rit.exe set env --env=test
         - name: RIT SHOW ENV command (2)
-          run:  |
-            .\rit.exe show env > check2.txt
-            diff check2.txt testdata/gha_workflows/env_workflow/assert2.txt
+          run: .\rit.exe show env > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT DELETE ENV command
           run: .\rit.exe delete env --env=test
         - name: RIT SHOW ENV command (3)
-          run:  |
-            .\rit.exe show env > check3.txt
-            diff check3.txt testdata/gha_workflows/env_workflow/assert1.txt
+          run: .\rit.exe show env > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/env_workflow/assert1.txt
+            expected_result: PASSED

--- a/.github/workflows/test-env-commands.yml
+++ b/.github/workflows/test-env-commands.yml
@@ -27,7 +27,7 @@ on:
       - '**/show_env.go'
       - '**/show_test.go'
       - '**/show.go'
-
+      - 'testdata/gha_workflows/env_workflow/**'
   pull_request:
     paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
       - '**/cmd.go'
@@ -43,6 +43,7 @@ on:
       - '**/show_env.go'
       - '**/show_test.go'
       - '**/show.go'
+      - 'testdata/gha_workflows/env_workflow/**'
 
 jobs:
   ubuntu:

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -14,7 +14,7 @@ jobs:
             make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
         - name: RIT INIT command (1)
           run:  |
-            rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt
+            rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
             diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
         - name: RIT TUTORIAL command (2)
           run:  |
@@ -40,3 +40,40 @@ jobs:
           run:  |
             sudo rit upgrade > check7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         
+
+  macos:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            cd $GITHUB_WORKSPACE
+            make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
+        - name: RIT INIT command (1)
+          run:  |
+            rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
+            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+        - name: RIT TUTORIAL command (2)
+          run:  |
+            rit tutorial --enabled=false > check2.txt
+            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - name: RIT TUTORIAL command (3)
+          run:  |
+            rit tutorial --enabled=true > check3.txt
+            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - name: RIT SET FORMULA-RUNNER command (4)
+          run:  |
+            rit set formula-runner --runner="local" > check4.txt
+            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - name: RIT SET FORMULA-RUNNER command (5)
+          run:  |
+            rit set formula-runner --runner="docker" > check5.txt
+            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - name: RIT --VERSION command (6)
+          run: |
+            rit --version > check6.txt
+            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
+        - name: RIT UPGRADE command (7)
+          run:  |
+            sudo rit upgrade > check7.txt
+            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt) 

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -34,5 +34,6 @@ jobs:
             diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt                  
         - name: RIT UPGRADE command (6)
           run:  |
+            rit --version
             rit upgrade > check6.txt
             diff check6.txt testdata/gha_workflows/global_workflow/assert6.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,7 +38,7 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
-            rit upgrade > check7.txt
+            rit upgrade <<EOF > check7.txt
             cat <<'EOF' >> check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -109,8 +109,9 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             .\rit.exe --version > check6.txt
-            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
+            cmd /c 'diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)'        
         - name: RIT UPGRADE command (7)
           run:  |
             .\rit.exe rit upgrade > check7.txt
-            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt) 
+            cmd /c 'diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)'
+            

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -49,7 +49,7 @@ jobs:
           run: |
             cd $GITHUB_WORKSPACE
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
-            rit init --sendMetrics="yes" --addCommons="no" --runType="local"
+            rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT INIT command (1)
           run:  |
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -42,14 +42,13 @@ jobs:
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         
 
   macos:
-      runs-on: ubuntu-latest
+      runs-on: macos-latest
       steps:
         - uses: actions/checkout@v2.3.4
         - name: Create binary from branch
           run: |
             cd $GITHUB_WORKSPACE
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
-            rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT INIT command (1)
           run:  |
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,7 +38,7 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
-            sudo rit upgrade > check7.txt
+            sudo rit upgrade >> check7.txt
             cat check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -89,7 +89,7 @@ jobs:
         - name: RIT INIT command (1)
           run:  |
             .\rit.exe init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
-            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+            diff check1.txt testdata/gha_workflows/global_workflow/assert1_win.txt
         - name: RIT TUTORIAL command (2)
           run:  |
             .\rit.exe tutorial --enabled=false > check2.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,8 +38,8 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (7)
           run:  |
-            rit upgrade
-            rit upgrade > check7.txt
+            sudo rit upgrade
+            sudo rit upgrade > check7.txt
             cat check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -15,31 +15,61 @@ jobs:
         - name: RIT INIT command (1)
           run:  |
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
-            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (2)
           run:  |
             rit tutorial --enabled=false > check2.txt
-            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (3)
           run:  |
             rit tutorial --enabled=true > check3.txt
-            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert3.txt
+            expected_result: PASSED    
         - name: RIT SET FORMULA-RUNNER command (4)
           run:  |
             rit set formula-runner --runner="local" > check4.txt
-            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert4.txt
+            expected_result: PASSED
         - name: RIT SET FORMULA-RUNNER command (5)
           run:  |
             rit set formula-runner --runner="docker" > check5.txt
-            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check5.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert5.txt
+            expected_result: PASSED
         - name: RIT --VERSION command (6)
           run: |
             rit --version > check6.txt
-            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check6.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert6.txt
+            expected_result: PASSED
+            specific_line: 1     
         - name: RIT UPGRADE command (7)
           run:  |
             sudo rit upgrade > check7.txt
-            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check7.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert7.txt
+            expected_result: PASSED
+            specific_line: 1
 
   macos:
       runs-on: macos-latest
@@ -52,31 +82,61 @@ jobs:
         - name: RIT INIT command (1)
           run:  |
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
-            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (2)
           run:  |
             rit tutorial --enabled=false > check2.txt
-            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (3)
           run:  |
             rit tutorial --enabled=true > check3.txt
-            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert3.txt
+            expected_result: PASSED    
         - name: RIT SET FORMULA-RUNNER command (4)
           run:  |
             rit set formula-runner --runner="local" > check4.txt
-            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert4.txt
+            expected_result: PASSED
         - name: RIT SET FORMULA-RUNNER command (5)
           run:  |
             rit set formula-runner --runner="docker" > check5.txt
-            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check5.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert5.txt
+            expected_result: PASSED
         - name: RIT --VERSION command (6)
           run: |
             rit --version > check6.txt
-            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check6.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert6.txt
+            expected_result: PASSED
+            specific_line: 1     
         - name: RIT UPGRADE command (7)
           run:  |
             sudo rit upgrade > check7.txt
-            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt) 
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check7.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert7.txt
+            expected_result: PASSED
+            specific_line: 1
 
   windows:
       runs-on: windows-latest

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -109,9 +109,11 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             .\rit.exe --version > check6.txt
-            cmd /c 'diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)'        
+            $ch6 = Get-Content .\check6.txt)[0]
+            $as6 = Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt)[0]
+            if ( $ch6 -cne $as6 ) { Exit }
+            # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
         - name: RIT UPGRADE command (7)
           run:  |
             .\rit.exe rit upgrade > check7.txt
-            cmd /c 'diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)'
-            
+            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -114,7 +114,7 @@ jobs:
             Compare-Object $ch6 $as6
             if ( $ch6 -cne $as6 ) 
             { 
-            Throw 'Error' 
+            Throw "Error" 
             }
         - name: RIT UPGRADE command (7)
           run:  |

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,7 +38,8 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
-            sudo rit upgrade >> check7.txt
+            rit upgrade
+            rit upgrade > check7.txt
             cat check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -113,6 +113,7 @@ jobs:
             $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
             Compare-Object $ch6 $as6
             if ( $ch6 -cne $as6 ) { Exit }
+            diff $ch6 $as6
             # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
         - name: RIT UPGRADE command (7)
           run:  |

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,7 +38,7 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
-            rit upgrade <<EOF > check7.txt
-            cat <<'EOF' >> check7.txt
+            rit upgrade > check7.txt
+            cat check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -112,10 +112,6 @@ jobs:
             $ch6 = (Get-Content .\check6.txt -First 1)
             $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
             Compare-Object $ch6 $as6
-            if ( $ch6 -cne $as6 ) 
-            { 
-            Throw "Error" 
-            }
         - name: RIT UPGRADE command (7)
           run:  |
             .\rit.exe rit upgrade > check7.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -112,9 +112,10 @@ jobs:
             $ch6 = (Get-Content .\check6.txt -First 1)
             $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
             Compare-Object $ch6 $as6
-            if ( $ch6 -cne $as6 ) { Exit }
-            diff $ch6 $as6
-            # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
+            if ( $ch6 -cne $as6 ) 
+            { 
+            Throw 'Error' 
+            }
         - name: RIT UPGRADE command (7)
           run:  |
             .\rit.exe rit upgrade > check7.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,7 +38,7 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
-            rit upgrade > check7.txt
+            sudo rit upgrade > check7.txt
             cat check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -35,10 +35,10 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             rit --version > check6.txt
-            cat check6.txt
-            cat testdata/gha_workflows/global_workflow/assert6.txt
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
             rit upgrade > check7.txt
+            cat check7.txt
+            cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -89,30 +89,58 @@ jobs:
         - name: RIT INIT command (1)
           run:  |
             .\rit.exe init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
-            diff check1.txt testdata/gha_workflows/global_workflow/assert1_win.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert1_win.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (2)
           run:  |
             .\rit.exe tutorial --enabled=false > check2.txt
-            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT TUTORIAL command (3)
           run:  |
             .\rit.exe tutorial --enabled=true > check3.txt
-            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert3.txt
+            expected_result: PASSED
         - name: RIT SET FORMULA-RUNNER command (4)
           run:  |
             .\rit.exe set formula-runner --runner="local" > check4.txt
-            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert4.txt
+            expected_result: PASSED
         - name: RIT SET FORMULA-RUNNER command (5)
           run:  |
             .\rit.exe set formula-runner --runner="docker" > check5.txt
-            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check5.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert5.txt
+            expected_result: PASSED
         - name: RIT --VERSION command (6)
           run: |
             .\rit.exe --version > check6.txt
-            $ch6 = (Get-Content .\check6.txt -First 1)
-            $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
-            Compare-Object $ch6 $as6
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check6.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert6.txt
+            expected_result: PASSED
+            specific_line: 1
         - name: RIT UPGRADE command (7)
           run:  |
             .\rit.exe rit upgrade > check7.txt
-            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check7.txt
+            second_file_path: testdata/gha_workflows/global_workflow/assert7.txt
+            expected_result: PASSED
+            specific_line: 1

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -51,6 +51,7 @@ jobs:
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
         - name: RIT INIT command (1)
           run:  |
+            rit init --sendMetrics="yes" --addCommons="no" --runType="local"
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
             diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
         - name: RIT TUTORIAL command (2)

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -37,13 +37,11 @@ jobs:
             rit --version > check6.txt
             cat check6.txt
             cat testdata/gha_workflows/global_workflow/assert6.txt
-            diff check6.txt testdata/gha_workflows/repo_workflow/assert6.txt
-            # rit --version > check6.txt
-            # if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
-            #   echo "Same 1st line"
-            # else
-            #   exit 1 #Error
-            # fi
+            if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
+              echo "Same 1st line"
+            else
+              exit 1 #Error
+            fi
             # if [[ $(head -4 check6.txt) = $(head -4 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
             #   echo "Same 4th line"
             # else

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -77,3 +77,40 @@ jobs:
           run:  |
             sudo rit upgrade > check7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt) 
+
+  windows:
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            choco install make
+            make build-windows && move D:\a\ritchie-cli\ritchie-cli\dist\windows\rit.exe "D:\a\ritchie-cli\ritchie-cli"
+        - name: RIT INIT command (1)
+          run:  |
+            .\rit.exe init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
+            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+        - name: RIT TUTORIAL command (2)
+          run:  |
+            .\rit.exe tutorial --enabled=false > check2.txt
+            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - name: RIT TUTORIAL command (3)
+          run:  |
+            .\rit.exe tutorial --enabled=true > check3.txt
+            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - name: RIT SET FORMULA-RUNNER command (4)
+          run:  |
+            .\rit.exe set formula-runner --runner="local" > check4.txt
+            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - name: RIT SET FORMULA-RUNNER command (5)
+          run:  |
+            .\rit.exe set formula-runner --runner="docker" > check5.txt
+            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - name: RIT --VERSION command (6)
+          run: |
+            .\rit.exe --version > check6.txt
+            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
+        - name: RIT UPGRADE command (7)
+          run:  |
+            .\rit.exe rit upgrade > check7.txt
+            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt) 

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -14,7 +14,7 @@ jobs:
             make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
         - name: RIT INIT command (1)
           run:  |
-            rit init --sendMetrics="no" --addCommons="no" --runType="local" > check1.txt
+            rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt
             diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
         - name: RIT TUTORIAL command (2)
           run:  |
@@ -36,7 +36,7 @@ jobs:
           run: |
             rit --version > check6.txt
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
-        - name: RIT UPGRADE command (6)
+        - name: RIT UPGRADE command (7)
           run:  |
             rit upgrade
             rit upgrade > check7.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -49,9 +49,9 @@ jobs:
           run: |
             cd $GITHUB_WORKSPACE
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
+            rit init --sendMetrics="yes" --addCommons="no" --runType="local"
         - name: RIT INIT command (1)
           run:  |
-            rit init --sendMetrics="yes" --addCommons="no" --runType="local"
             rit init --sendMetrics="yes" --addCommons="no" --runType="local" > check1.txt # Need to accept metrics here, otherwise RIT UPGRADE command ask for them through prompt.
             diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
         - name: RIT TUTORIAL command (2)

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -1,7 +1,44 @@
 name: Test Global Commands
 
+# TXT files used for ASSERT are located on the /testdata/gha_workflows directory.
+
+# To help you coding your workflow tests, you can use CAT commands to show each file you will compare on the workflow window on Github.
+
+# EXAMPLE:
+#   rit init > check1.txt
+#   cat check1.txt
+#   cat testdata/gha_workflows/global_workflow/assert1.txt
+#   diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Can be triggered manually through the ACTIONS tab on Github GUI.
+  push:
+    paths: # Will trigger on PUSH event that update at least one of those files.
+      - '**/cmd.go'
+      - '**/init_test.go'
+      - '**/init.go'
+      - '**/root_test.go'
+      - '**/root.go'
+      - '**/set_formula_runner_test.go'
+      - '**/set_formula_runner.go'
+      - '**/tutorial_test.go'
+      - '**/tutorial.go'
+      - '**/upgrade_test.go'
+      - '**/upgrade.go'
+
+  pull_request:
+    paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
+      - '**/cmd.go'
+      - '**/init_test.go'
+      - '**/init.go'
+      - '**/root_test.go'
+      - '**/root.go'
+      - '**/set_formula_runner_test.go'
+      - '**/set_formula_runner.go'
+      - '**/tutorial_test.go'
+      - '**/tutorial.go'
+      - '**/upgrade_test.go'
+      - '**/upgrade.go'
 
 jobs:
   ubuntu:

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -39,6 +39,6 @@ jobs:
         - name: RIT UPGRADE command (6)
           run:  |
             rit upgrade > check7.txt
-            cat check7.txt
+            cat <<'EOF' >> check7.txt
             cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -112,7 +112,7 @@ jobs:
             $ch6 = (Get-Content .\check6.txt -First 1)
             $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
             Compare-Object $ch6 $as6
-            if ( $ch6 -nec $as6 ) { Exit }
+            if ( $ch6 -cne $as6 ) { Exit }
             # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
         - name: RIT UPGRADE command (7)
           run:  |

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -37,21 +37,8 @@ jobs:
             rit --version > check6.txt
             cat check6.txt
             cat testdata/gha_workflows/global_workflow/assert6.txt
-            if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
-              echo "Same 1st line"
-            else
-              exit 1 #Error
-            fi
-            # if [[ $(head -4 check6.txt) = $(head -4 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
-            #   echo "Same 4th line"
-            # else
-            #   exit 1 #Error
-            # fi               
+            diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (6)
           run:  |
             rit upgrade > check7.txt
-            if [[ $(head -1 check7.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert7.txt) ]]; then
-              echo "Same first line"
-            else
-              exit 1 #Error
-            fi   
+            diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -109,9 +109,9 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             .\rit.exe --version > check6.txt
-            $ch6 = Get-Content .\check6.txt)[0]
-            $as6 = Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt)[0]
-            if ( $ch6 -cne $as6 ) { Exit }
+            $ch6 = (Get-Content .\check6.txt)[0]
+            $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt)[0]
+            Compare-Object $ch6 $as6
             # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
         - name: RIT UPGRADE command (7)
           run:  |

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -35,16 +35,20 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             rit --version > check6.txt
-            if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
-              echo "Same 1st line"
-            else
-              exit 1 #Error
-            fi
-            if [[ $(head -4 check6.txt) = $(head -4 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
-              echo "Same 4th line"
-            else
-              exit 1 #Error
-            fi               
+            cat check6.txt
+            cat testdata/gha_workflows/global_workflow/assert6.txt
+            diff check6.txt testdata/gha_workflows/repo_workflow/assert6.txt
+            # rit --version > check6.txt
+            # if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
+            #   echo "Same 1st line"
+            # else
+            #   exit 1 #Error
+            # fi
+            # if [[ $(head -4 check6.txt) = $(head -4 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
+            #   echo "Same 4th line"
+            # else
+            #   exit 1 #Error
+            # fi               
         - name: RIT UPGRADE command (6)
           run:  |
             rit upgrade > check7.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -197,7 +197,7 @@ jobs:
             specific_line: 1
         - name: RIT UPGRADE command (7)
           run:  |
-            .\rit.exe rit upgrade > check7.txt
+            .\rit.exe upgrade > check7.txt
         - uses: GuillaumeFalourd/diff-action@v1
           with:
             first_file_path: check7.txt

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -31,9 +31,25 @@ jobs:
         - name: RIT SET FORMULA-RUNNER command (5)
           run:  |
             rit set formula-runner --runner="docker" > check5.txt
-            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt                  
+            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt
+        - name: RIT --VERSION command (6)
+          run: |
+            rit --version > check6.txt
+            if [[ $(head -1 check6.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
+              echo "Same 1st line"
+            else
+              exit 1 #Error
+            fi
+            if [[ $(head -4 check6.txt) = $(head -4 testdata/gha_workflows/global_workflow/assert6.txt) ]]; then
+              echo "Same 4th line"
+            else
+              exit 1 #Error
+            fi               
         - name: RIT UPGRADE command (6)
           run:  |
-            rit --version
-            rit upgrade > check6.txt
-            diff check6.txt testdata/gha_workflows/global_workflow/assert6.txt
+            rit upgrade > check7.txt
+            if [[ $(head -1 check7.txt) = $(head -1 testdata/gha_workflows/global_workflow/assert7.txt) ]]; then
+              echo "Same first line"
+            else
+              exit 1 #Error
+            fi   

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -109,9 +109,10 @@ jobs:
         - name: RIT --VERSION command (6)
           run: |
             .\rit.exe --version > check6.txt
-            $ch6 = (Get-Content .\check6.txt)[0]
-            $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt)[0]
+            $ch6 = (Get-Content .\check6.txt -First 1)
+            $as6 = (Get-Content .\testdata/gha_workflows/global_workflow/assert6.txt -First 1)
             Compare-Object $ch6 $as6
+            if ( $ch6 -nec $as6 ) { Exit }
             # diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)      
         - name: RIT UPGRADE command (7)
           run:  |

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -25,7 +25,7 @@ on:
       - '**/tutorial.go'
       - '**/upgrade_test.go'
       - '**/upgrade.go'
-
+      - 'testdata/gha_workflows/global_workflow/**'
   pull_request:
     paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
       - '**/cmd.go'
@@ -39,6 +39,7 @@ on:
       - '**/tutorial.go'
       - '**/upgrade_test.go'
       - '**/upgrade.go'
+      - 'testdata/gha_workflows/global_workflow/**'
 
 jobs:
   ubuntu:

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -38,8 +38,5 @@ jobs:
             diff <(head -n 1 check6.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert6.txt)         
         - name: RIT UPGRADE command (7)
           run:  |
-            sudo rit upgrade
             sudo rit upgrade > check7.txt
-            cat check7.txt
-            cat testdata/gha_workflows/global_workflow/assert7.txt
             diff <(head -n 1 check7.txt) <(head -n 1 testdata/gha_workflows/global_workflow/assert7.txt)         

--- a/.github/workflows/test-global-commands.yml
+++ b/.github/workflows/test-global-commands.yml
@@ -1,0 +1,38 @@
+name: Test Global Commands
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ubuntu:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2.3.4
+        - name: Create binary from branch
+          run: |
+            cd $GITHUB_WORKSPACE
+            make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
+        - name: RIT INIT command (1)
+          run:  |
+            rit init --sendMetrics="no" --addCommons="no" --runType="local" > check1.txt
+            diff check1.txt testdata/gha_workflows/global_workflow/assert1.txt
+        - name: RIT TUTORIAL command (2)
+          run:  |
+            rit tutorial --enabled=false > check2.txt
+            diff check2.txt testdata/gha_workflows/global_workflow/assert2.txt
+        - name: RIT TUTORIAL command (3)
+          run:  |
+            rit tutorial --enabled=true > check3.txt
+            diff check3.txt testdata/gha_workflows/global_workflow/assert3.txt      
+        - name: RIT SET FORMULA-RUNNER command (4)
+          run:  |
+            rit set formula-runner --runner="local" > check4.txt
+            diff check4.txt testdata/gha_workflows/global_workflow/assert4.txt
+        - name: RIT SET FORMULA-RUNNER command (5)
+          run:  |
+            rit set formula-runner --runner="docker" > check5.txt
+            diff check5.txt testdata/gha_workflows/global_workflow/assert5.txt                  
+        - name: RIT UPGRADE command (6)
+          run:  |
+            rit upgrade > check6.txt
+            diff check6.txt testdata/gha_workflows/global_workflow/assert6.txt

--- a/.github/workflows/test-repo-commands.yml
+++ b/.github/workflows/test-repo-commands.yml
@@ -62,27 +62,39 @@ jobs:
             make build-linux && sudo mv ./dist/linux/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST REPO command (1)
-          run:  |
-            rit list repo > check1.txt
-            diff check1.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: rit list repo > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT ADD REPO command
           run: rit add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1 --tag="2.2.0"
         - name: RIT LIST REPO command (2)
-          run:  |
-            rit list repo > check2.txt
-            diff check2.txt testdata/gha_workflows/repo_workflow/assert2.txt
+          run: rit list repo > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT UPDATE REPO command
           run: rit update repo --name="demo" --version="2.3.0"
         - name: RIT LIST REPO command (3)
-          run:  |
-            rit list repo > check3.txt
-            diff check3.txt testdata/gha_workflows/repo_workflow/assert3.txt
+          run: rit list repo > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert3.txt
+            expected_result: PASSED
         - name: RIT DELETE REPO command
           run: rit delete repo --name="demo"
         - name: RIT LIST REPO command (4)
-          run:  |
-            rit list repo > check4.txt
-            diff check4.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: rit list repo > check4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED
 
   macos:
       runs-on: macos-latest
@@ -94,28 +106,39 @@ jobs:
             make build-mac && sudo mv ./dist/darwin/rit /usr/local/bin
             rit init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST REPO command (1)
-          run:  |
-            rit list repo > check1.txt
-            diff check1.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: rit list repo > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT ADD REPO command
           run: rit add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1 --tag="2.2.0"
         - name: RIT LIST REPO command (2)
-          run:  |
-            rit list repo 2> /dev/null
-            rit list repo > check2.txt
-            diff check2.txt testdata/gha_workflows/repo_workflow/assert2.txt
+          run: rit list repo > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT UPDATE REPO command
           run: rit update repo --name="demo" --version="2.3.0"
         - name: RIT LIST REPO command (3)
-          run:  |
-            rit list repo > check3.txt
-            diff check3.txt testdata/gha_workflows/repo_workflow/assert3.txt
+          run: rit list repo > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert3.txt
+            expected_result: PASSED
         - name: RIT DELETE REPO command
           run: rit delete repo --name="demo"
         - name: RIT LIST REPO command (4)
-          run:  |
-            rit list repo > check4.txt
-            diff check4.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: rit list repo > check4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED
 
   windows:
       runs-on: windows-latest
@@ -128,24 +151,36 @@ jobs:
             ls
             .\rit.exe init --sendMetrics="no" --addCommons="no" --runType="local"
         - name: RIT LIST REPO command (1)
-          run:  |
-            .\rit.exe list repo > check1.txt
-            diff check1.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: .\rit.exe list repo > check1.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check1.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED
         - name: RIT ADD REPO command
-          run: .\rit add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1 --tag="2.2.0"
+          run: .\rit.exe add repo --provider="Github" --name="demo" --repoUrl="https://github.com/ZupIT/ritchie-formulas-demo" --priority=1 --tag="2.2.0"
         - name: RIT LIST REPO command (2)
-          run:  |
-            .\rit.exe list repo > check2.txt
-            diff check2.txt testdata/gha_workflows/repo_workflow/assert2.txt
+          run: .\rit.exe list repo > check2.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check2.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert2.txt
+            expected_result: PASSED
         - name: RIT UPDATE REPO command
           run: .\rit.exe update repo --name="demo" --version="2.3.0"
         - name: RIT LIST REPO command (3)
-          run:  |
-            .\rit.exe list repo > check3.txt
-            diff check3.txt testdata/gha_workflows/repo_workflow/assert3.txt
+          run: .\rit.exe list repo > check3.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check3.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert3.txt
+            expected_result: PASSED
         - name: RIT DELETE REPO command
           run: .\rit.exe delete repo --name="demo"
         - name: RIT LIST REPO command (4)
-          run:  |
-            .\rit.exe list repo > check4.txt
-            diff check4.txt testdata/gha_workflows/repo_workflow/assert1.txt
+          run: .\rit.exe list repo > check4.txt
+        - uses: GuillaumeFalourd/diff-action@v1
+          with:
+            first_file_path: check4.txt
+            second_file_path: testdata/gha_workflows/repo_workflow/assert1.txt
+            expected_result: PASSED

--- a/.github/workflows/test-repo-commands.yml
+++ b/.github/workflows/test-repo-commands.yml
@@ -31,6 +31,7 @@ on:
       - '**/update_repo.go'
       - '**/update_test.go'
       - '**/update.go'
+      - 'testdata/gha_workflows/repo_workflow/**'
   pull_request:
     paths: # Will trigger on PULL_REQUEST event that update at least one of those files.
       - '**/add_test.go'
@@ -50,6 +51,7 @@ on:
       - '**/update_repo.go'
       - '**/update_test.go'
       - '**/update.go'
+      - 'testdata/gha_workflows/repo_workflow/**'
 
 jobs:
   ubuntu:

--- a/testdata/gha_workflows/global_workflow/assert1.txt
+++ b/testdata/gha_workflows/global_workflow/assert1.txt
@@ -1,0 +1,40 @@
+ _______       _     _             __         _                           ______    _____      _____  
+|_   __ \     (_)   / |_          [  |       (_)                        .' ___  |  |_   _|    |_   _| 
+  | |__) |    __   `| |-'  .---.   | |--.    __    .---.     ______    / .'   \_|    | |        | |   
+  |  __ /    [  |   | |   / /'`\]  | .-. |  [  |  / /__\\   |______|   | |           | |   _    | |   
+ _| |  \ \_   | |   | |,  | \__.   | | | |   | |  | \__.,              \ `.___.'\   _| |__/ |  _| |_  
+|____| |___| [___]  \__/  '.___.' [___]|__] [___]  '.__.'               `.____ .'  |________| |_____| 
+
+
+Ritchie is a platform that helps you and your team to save time by
+giving you the power to create powerful templates to execute important
+tasks across your team and organization with minimum time and with standards,
+delivering autonomy to developers with security.
+
+You can view our Privacy Policy (http://insights.zup.com.br/politica-privacidade) to better understand our commitment.
+
+
+			⚠️  WARNING ⚠️
+
+You can keep the configuration without adding the community repository,
+but you will need to provide a git repo with the formulas templates and add them with
+"rit add repo" command, naming this repository obligatorily as "commons".
+
+See how to do this on the example:
+[https://github.com/ZupIT/ritchie-formulas/blob/master/templates/create_formula/README.md]
+
+Run "rit add repo" to add a new repository manually.
+
+
+✅ Initialization successful!
+
+
+📖 TUTORIAL 📖
+
+How to create new formulas:
+
+∙ Run "rit create formula"
+∙ Open the project with your favorite text editor.
+
+Take a look at the formulas you can run and test to see what you can with Ritchie using "rit"
+

--- a/testdata/gha_workflows/global_workflow/assert1_win.txt
+++ b/testdata/gha_workflows/global_workflow/assert1_win.txt
@@ -1,0 +1,40 @@
+ _______       _     _             __         _                           ______    _____      _____  
+|_   __ \     (_)   / |_          [  |       (_)                        .' ___  |  |_   _|    |_   _| 
+  | |__) |    __   `| |-'  .---.   | |--.    __    .---.     ______    / .'   \_|    | |        | |   
+  |  __ /    [  |   | |   / /'`\]  | .-. |  [  |  / /__\\   |______|   | |           | |   _    | |   
+ _| |  \ \_   | |   | |,  | \__.   | | | |   | |  | \__.,              \ `.___.'\   _| |__/ |  _| |_  
+|____| |___| [___]  \__/  '.___.' [___]|__] [___]  '.__.'               `.____ .'  |________| |_____| 
+
+
+Ritchie is a platform that helps you and your team to save time by
+giving you the power to create powerful templates to execute important
+tasks across your team and organization with minimum time and with standards,
+delivering autonomy to developers with security.
+
+You can view our Privacy Policy (http://insights.zup.com.br/politica-privacidade) to better understand our commitment.
+
+
+			 WARNING
+
+You can keep the configuration without adding the community repository,
+but you will need to provide a git repo with the formulas templates and add them with
+"rit add repo" command, naming this repository obligatorily as "commons".
+
+See how to do this on the example:
+[https://github.com/ZupIT/ritchie-formulas/blob/master/templates/create_formula/README.md]
+
+Run "rit add repo" to add a new repository manually.
+
+
+ Initialization successful!
+
+
+ TUTORIAL
+
+How to create new formulas:
+
+∙ Run "rit create formula"
+∙ Open the project with your favorite text editor.
+
+Take a look at the formulas you can run and test to see what you can with Ritchie using "rit"
+

--- a/testdata/gha_workflows/global_workflow/assert2.txt
+++ b/testdata/gha_workflows/global_workflow/assert2.txt
@@ -1,0 +1,1 @@
+Tutorial disabled!

--- a/testdata/gha_workflows/global_workflow/assert3.txt
+++ b/testdata/gha_workflows/global_workflow/assert3.txt
@@ -1,0 +1,1 @@
+Tutorial enabled!

--- a/testdata/gha_workflows/global_workflow/assert4.txt
+++ b/testdata/gha_workflows/global_workflow/assert4.txt
@@ -1,0 +1,5 @@
+The default formula runner has been successfully configured!
+
+In order to run formulas locally, you must have the formula language installed on your machine,
+if you don't want to install choose to run the formulas inside the docker.
+

--- a/testdata/gha_workflows/global_workflow/assert5.txt
+++ b/testdata/gha_workflows/global_workflow/assert5.txt
@@ -1,0 +1,1 @@
+The default formula runner has been successfully configured!

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,1 +1,4 @@
-rit version
+rit version 
+  Latest available version: 2.11.3
+  Build date: 06/16/21_17:22
+  Built with: go1.15.6

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,4 +1,4 @@
-rit version
+rit version 
   Latest available version: 2.11.3
   Build date: MM/DD/YY_HH:MM
   Built with: go1.15.6

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,3 +1,4 @@
-Rit upgraded with success
-Release 2.11.3 description:
-- Fix bug with formula's outputs #934
+rit version
+  Latest available version: 2.11.3
+  Build date: MM/DD/YY_HH:MM
+  Built with: go1.15.6

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,4 +1,1 @@
 rit version 
-  Latest available version: 2.11.3
-  Build date: MM/DD/YY_HH:MM
-  Built with: go1.15.6

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,1 +1,1 @@
-rit version
+rit version 1

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,1 +1,1 @@
-rit version 
+rit version 1

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,1 +1,1 @@
-rit version 1
+rit version

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,0 +1,3 @@
+Rit upgraded with success
+Release 2.11.3 description:
+- Fix bug with formula's outputs #934

--- a/testdata/gha_workflows/global_workflow/assert6.txt
+++ b/testdata/gha_workflows/global_workflow/assert6.txt
@@ -1,4 +1,4 @@
 rit version 
-  Latest available version: 2.11.3
-  Build date: 06/16/21_17:22
-  Built with: go1.15.6
+  Latest available version: 2.XX.Y
+  Build date: MM/DD/YY_HH:MM
+  Built with: go1.XX.Y

--- a/testdata/gha_workflows/global_workflow/assert7.txt
+++ b/testdata/gha_workflows/global_workflow/assert7.txt
@@ -1,0 +1,1 @@
+Rit upgraded with success


### PR DESCRIPTION
### Description

Closes: https://github.com/ZupIT/ritchie-cli/issues/959

- Funcional tests using **rit** binaries for each OS, for the `global` core commands. Those kind of tests could improve the project quality and future pipeline performances by testing only what matters on each contribution, instead of testing everything every time.

- This workflow will trigger every time one of the paths informed files is updated, by a `PULL REQUEST` event or a `PUSH` event.

- The workflow executes in **parallel** jobs on `windows`, `ubuntu` and `macOS` where each job will:
    - use the make command to generate rit binary for the OS.
    - execute synchronously the following steps: `rit init`, `rit upgrade`, `rit tutorial `, `rit --version`, `rit set formula-runner`.
    - after each step, a check run is performed using `diff` command to assert the output is as expected.

- Expected outputs need to be added to the `/testdata/gha_workflows` directory, currently on the `.txt` format

### Update with diff action

- During tests, it was observed that the WINDOWS diff commands weren't working as expected for other workflows. Therefore, I decided to create [a github composite action](https://github.com/GuillaumeFalourd/diff-action) to perform this command comparison, supporting it for each OS. I updated the other workflows with it and the outputs can be checked here:
   - Test Repo Commands: [workflow run](https://github.com/GuillaumeFalourd/ritchie-cli/runs/2843123885?check_suite_focus=true)
   - Test Env Commands: [workflow run](https://github.com/GuillaumeFalourd/ritchie-cli/runs/2843123593?check_suite_focus=true)
   - Test Credential Commands: [workflow run](https://github.com/GuillaumeFalourd/ritchie-cli/runs/2843137344?check_suite_focus=true)

### How to verify it

- You can check the workflow execution on [this fork](https://github.com/GuillaumeFalourd/ritchie-cli/actions/workflows/test-global-commands.yml)

Here are some samples:

![Screen Shot 2021-06-16 at 17 47 07](https://user-images.githubusercontent.com/22433243/122291213-f2f83300-ceca-11eb-83ab-ac6fdafe1dcb.png)

![Screen Shot 2021-06-16 at 17 47 15](https://user-images.githubusercontent.com/22433243/122291226-f8557d80-ceca-11eb-86da-5ad551b63d66.png)

[Reference](https://github.com/GuillaumeFalourd/ritchie-cli/actions/runs/944198450)

### Changelog

- Adding Github Action workflow performing funcional tests using **rit** binaries for each OS, for the `global` core commands.
 