### PR TITLE
Update build-macos-x64.sh script removing certificate prompt

### DIFF
--- a/packaging/mac-pkg/build-macos-x64.sh
+++ b/packaging/mac-pkg/build-macos-x64.sh
@@ -163,12 +163,16 @@ function createInstaller() {
     log_info "Application installer generation process started.(3 Steps)"
     buildPackage
     buildProduct ${PRODUCT}-macos-installer-x64-${VERSION}.pkg
-    while true; do
-        read -p "Do you wish to sign the installer (You should have Apple Developer Certificate) [y/N]?" answer
-        [[ $answer == "y" || $answer == "Y" ]] && FLAG=true && break
-        [[ $answer == "n" || $answer == "N" || $answer == "" ]] && log_info "Skiped signing process." && FLAG=false && break
-        echo "Please answer with 'y' or 'n'"
-    done
+    # TODO: No signing process at the moment, update this part when available.
+
+    # while true; do
+    #     read -p "Do you wish to sign the installer (You should have Apple Developer Certificate) [y/N]?" answer
+    #     [[ $answer == "y" || $answer == "Y" ]] && FLAG=true && break
+    #     [[ $answer == "n" || $answer == "N" || $answer == "" ]] && log_info "Skiped signing process." && FLAG=false && break
+    #     echo "Please answer with 'y' or 'n'"
+    # done
+    
+    log_info "Skiped signing process." && FLAG=false
     [[ $FLAG == "true" ]] && signProduct ${PRODUCT}-macos-installer-x64-${VERSION}.pkg
     log_info "Application installer generation steps finished."
 }


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

### Why is this necessary

To remove the certificate prompt display as explained on https://github.com/ZupIT/ritchie-cli/pull/946 as we don't have any process about it yet.

### How to verify it

- Create an `Application` folder on `packaging/mac-pkg` folder.
- At the repository root, run `make build-mac && sudo mv ./dist/darwin/rit ./packaging/mac-pkg/Application`.
- Access the mac-pkg folder: `cd packaging/mac-pkg`
- Run `bash build-macos-x64.sh rit <version>`
- Your package file should be available at `packaging/mac-pkg/target/pkg`

**Demo**

![demo](https://user-images.githubusercontent.com/22433243/123148428-9949b880-d436-11eb-9066-a44d60224470.png)

### Changelog

- Update build-macos-x64.sh script removing certificate prompt