### PR TITLE
Support flags to metrics command

### DIFF
--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"errors"
+	"reflect"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ZupIT/ritchie-cli/pkg/metric"
@@ -13,6 +17,19 @@ type metricsCmd struct {
 	input prompt.InputList
 }
 
+var metricsFlagName = "metrics"
+var metricsFlags = flags{
+	{
+		name:        metricsFlagName,
+		shortName:   "",
+		kind:        reflect.String,
+		defValue:    "yes",
+		description: "",
+	},
+}
+var message string
+var options = []string{"yes", "no"}
+
 func NewMetricsCmd(file stream.FileWriteReadExister, inList prompt.InputList) *cobra.Command {
 	m := &metricsCmd{
 		file:  file,
@@ -23,28 +40,25 @@ func NewMetricsCmd(file stream.FileWriteReadExister, inList prompt.InputList) *c
 		Use:       "metrics",
 		Short:     "Turn metrics on and off",
 		Long:      "Stop or start to send anonymous metrics to ritchie team.",
-		RunE:      m.run(),
+		RunE:      m.runCmd(),
 		ValidArgs: []string{""},
 		Args:      cobra.OnlyValidArgs,
 	}
-
+	cmd.LocalFlags()
+	addReservedFlags(cmd.Flags(), metricsFlags)
 	return cmd
 
 }
 
-func (m metricsCmd) run() CommandRunnerFunc {
+func (m metricsCmd) runCmd() CommandRunnerFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		options := []string{"yes", "no"}
-		choose, err := m.input.List(
-			"You want to send anonymous data about the product, feature use, statistics and crash reports?",
-			options,
-		)
+		choose, err := m.resolveInput(cmd)
 		if err != nil {
 			return err
 		}
-
-		message := "You are now sending anonymous metrics. Thank you!"
-		if choose == "no" {
+		if choose == "yes" {
+			message = "You are now sending anonymous metrics. Thank you!"
+		} else if choose == "no" {
 			message = "You are no longer sending anonymous metrics."
 		}
 
@@ -55,4 +69,39 @@ func (m metricsCmd) run() CommandRunnerFunc {
 		prompt.Info(message)
 		return nil
 	}
+}
+
+func (m metricsCmd) resolveInput(cmd *cobra.Command) (string, error) {
+	if IsFlagInput(cmd) {
+		return m.runFlag(cmd)
+	} else {
+		return m.runPrompt()
+	}
+}
+
+func (m metricsCmd) runFlag(cmd *cobra.Command) (string, error) {
+	choose, err := cmd.Flags().GetString(metricsFlagName)
+	if err != nil {
+		return "", err
+	}
+	for i := range options {
+		if strings.EqualFold(choose, options[i]) {
+			break
+		} else if i == len(options)-1{
+			return "", errors.New("please provide a valid value to the flag metrics")
+		}
+
+	}
+	return choose, nil
+}
+
+func (m metricsCmd) runPrompt() (string, error) {
+	choose, err := m.input.List(
+		"You want to send anonymous data about the product, feature use, statistics and crash reports?",
+		options,
+	)
+	if err != nil {
+		return "", err
+	}
+	return choose, nil
 }

--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -87,7 +87,7 @@ func (m metricsCmd) runFlag(cmd *cobra.Command) (string, error) {
 	for i := range options {
 		if strings.EqualFold(choose, options[i]) {
 			break
-		} else if i == len(options)-1{
+		} else if i == len(options)-1 {
 			return "", errors.New("please provide a valid value to the flag metrics")
 		}
 

--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -97,7 +97,7 @@ func (m metricsCmd) runFlag(cmd *cobra.Command) (string, error) {
 
 func (m metricsCmd) runPrompt() (string, error) {
 	choose, err := m.input.List(
-		"You want to send anonymous data about the product, feature use, statistics and crash reports?",
+		"Do you want to send anonymous data about the product, feature use, statistics and crash reports?",
 		options,
 	)
 	if err != nil {

--- a/pkg/cmd/metrics_test.go
+++ b/pkg/cmd/metrics_test.go
@@ -175,9 +175,10 @@ func Test_RunFlag(t *testing.T) {
 			got, err := newMetrics.runFlag(metricsCmd)
 
 			if err != nil {
+				assert.Equal(t, err, tt.want)
+			} else {
 				assert.Equal(t, got, tt.choose)
 			}
-			assert.Equal(t, err, tt.want)
 
 		})
 	}

--- a/pkg/cmd/metrics_test.go
+++ b/pkg/cmd/metrics_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/ZupIT/ritchie-cli/pkg/prompt"
@@ -9,7 +10,7 @@ import (
 	sMocks "github.com/ZupIT/ritchie-cli/pkg/stream/mocks"
 )
 
-func Test_metricsCmd_runPrompt(t *testing.T) {
+func Test_metricsCmd_runCmd(t *testing.T) {
 	type in struct {
 		file  stream.FileWriteReadExister
 		input prompt.InputList
@@ -112,6 +113,41 @@ func Test_metricsCmd_runPrompt(t *testing.T) {
 			if err := metricsCmd.Execute(); (err != nil) != tt.wantErr {
 				t.Errorf("metrics command error = %v | error wanted: %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_RunFlag(t *testing.T) {
+	var runFlagCases = []struct {
+		fileMock  stream.FileWriteReadExister
+		inputMock prompt.InputList
+		choose    string
+		name      string
+		want      error
+	}{
+		{
+			name:   "success with yes",
+			choose: "yes",
+			want:   nil,
+		},
+		{
+			name:   "error invalid flag value",
+			choose: "invalid",
+			want:   errors.New("please provide a valid value to the flag metrics"),
+		},
+	}
+
+	for _, tt := range runFlagCases {
+		t.Run(tt.name, func(t *testing.T) {
+			newMetrics := metricsCmd{
+				file:  tt.fileMock,
+				input: tt.inputMock,
+			}
+			cobraCmd := NewMetricsCmd(tt.fileMock, tt.inputMock)
+			cobraCmd.Flags().Set(metricsFlagName, tt.choose)
+			got, err := newMetrics.runFlag(cobraCmd)
+			fmt.Println(got, err)
+
 		})
 	}
 }

--- a/pkg/cmd/metrics_test.go
+++ b/pkg/cmd/metrics_test.go
@@ -29,10 +29,22 @@ func Test_RunCmd(t *testing.T) {
 			want:         nil,
 		},
 		{
+			name:         "failed  with prompt",
+			choose:       "yes",
+			inputFileErr: errors.New("failed to write file"),
+			want:         errors.New("failed to write file"),
+		},
+		{
 			name:         "success with flags",
-			inputFileErr: nil,
 			inputFlag:    []string{"--metrics=no"},
+			inputFileErr: nil,
 			want:         nil,
+		},
+		{
+			name:         "fail with flags",
+			inputFlag:    []string{"--metrics=no"},
+			inputFileErr: errors.New("failed to write file"),
+			want:         errors.New("failed to write file"),
 		},
 	}
 

--- a/pkg/cmd/metrics_test.go
+++ b/pkg/cmd/metrics_test.go
@@ -146,11 +146,11 @@ func Test_RunPrompt(t *testing.T) {
 
 func Test_RunFlag(t *testing.T) {
 	var runFlagCases = []struct {
-		fileMock  stream.FileWriteReadExister
-		inputMock prompt.InputList
-		choose    string
-		name      string
-		want      error
+		writeFileMock stream.FileWriteReadExister
+		inputListMock prompt.InputList
+		choose        string
+		name          string
+		want          error
 	}{
 		{
 			name:   "success with yes",
@@ -167,13 +167,17 @@ func Test_RunFlag(t *testing.T) {
 	for _, tt := range runFlagCases {
 		t.Run(tt.name, func(t *testing.T) {
 			newMetrics := metricsCmd{
-				file:  tt.fileMock,
-				input: tt.inputMock,
+				file:  tt.writeFileMock,
+				input: tt.inputListMock,
 			}
-			cobraCmd := NewMetricsCmd(tt.fileMock, tt.inputMock)
-			cobraCmd.Flags().Set(metricsFlagName, tt.choose)
-			got, err := newMetrics.runFlag(cobraCmd)
-			fmt.Println(got, err)
+			metricsCmd := NewMetricsCmd(tt.writeFileMock, tt.inputListMock)
+			metricsCmd.Flags().Set(metricsFlagName, tt.choose)
+			got, err := newMetrics.runFlag(metricsCmd)
+
+			if err != nil {
+				assert.Equal(t, got, tt.choose)
+			}
+			assert.Equal(t, err, tt.want)
 
 		})
 	}

--- a/pkg/cmd/metrics_test.go
+++ b/pkg/cmd/metrics_test.go
@@ -5,116 +5,197 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ZupIT/ritchie-cli/internal/mocks"
 	"github.com/ZupIT/ritchie-cli/pkg/prompt"
 	"github.com/ZupIT/ritchie-cli/pkg/stream"
-	sMocks "github.com/ZupIT/ritchie-cli/pkg/stream/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func Test_metricsCmd_runCmd(t *testing.T) {
-	type in struct {
-		file  stream.FileWriteReadExister
-		input prompt.InputList
-	}
+// func Test_metricsCmd_runCmd(t *testing.T) {
+// 	type in struct {
+// 		file  stream.FileWriteReadExister
+// 		input prompt.InputList
+// 	}
+//
+// 	var tests = []struct {
+// 		name    string
+// 		wantErr bool
+// 		in      in
+// 	}{
+// 		{
+// 			name:    "success when metrics file dont exist",
+// 			wantErr: false,
+// 			in: in{
+// 				file: sMocks.FileWriteReadExisterCustomMock{
+// 					ExistsMock: func(path string) bool {
+// 						return false
+// 					},
+// 					ReadMock: func(path string) ([]byte, error) {
+// 						return []byte("some data"), nil
+// 					},
+// 					WriteMock: func(path string, content []byte) error {
+// 						return nil
+// 					},
+// 				},
+// 				input: inputListCustomMock{
+// 					list: func(name string, items []string) (string, error) {
+// 						return "yes", nil
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name:    "success when not accept send metrics",
+// 			wantErr: false,
+// 			in: in{
+// 				file: sMocks.FileWriteReadExisterCustomMock{
+// 					ExistsMock: func(path string) bool {
+// 						return false
+// 					},
+// 					ReadMock: func(path string) ([]byte, error) {
+// 						return []byte("some data"), nil
+// 					},
+// 					WriteMock: func(path string, content []byte) error {
+// 						return nil
+// 					},
+// 				},
+// 				input: inputListCustomMock{
+// 					list: func(name string, items []string) (string, error) {
+// 						return "no", nil
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name:    "fail on write file when metrics file dont exist",
+// 			wantErr: true,
+// 			in: in{
+// 				file: sMocks.FileWriteReadExisterCustomMock{
+// 					ExistsMock: func(path string) bool {
+// 						return false
+// 					},
+// 					ReadMock: func(path string) ([]byte, error) {
+// 						return []byte("some data"), nil
+// 					},
+// 					WriteMock: func(path string, content []byte) error {
+// 						return errors.New("reading file error")
+// 					},
+// 				},
+// 				input: inputListCustomMock{
+// 					list: func(name string, items []string) (string, error) {
+// 						return "yes", nil
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name:    "fail on input list when metrics file dont exist",
+// 			wantErr: true,
+// 			in: in{
+// 				file: sMocks.FileWriteReadExisterCustomMock{
+// 					ExistsMock: func(path string) bool {
+// 						return false
+// 					},
+// 					ReadMock: func(path string) ([]byte, error) {
+// 						return []byte("some data"), nil
+// 					},
+// 					WriteMock: func(path string, content []byte) error {
+// 						return nil
+// 					},
+// 				},
+// 				input: inputListErrorMock{},
+// 			},
+// 		},
+// 	}
+//
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			metricsCmd := NewMetricsCmd(tt.in.file, tt.in.input)
+// 			if err := metricsCmd.Execute(); (err != nil) != tt.wantErr {
+// 				t.Errorf("metrics command error = %v | error wanted: %v", err, tt.wantErr)
+// 			}
+// 		})
+// 	}
+// }
+
+
+func Test_ResolveInput(t *testing.T) {
 
 	var tests = []struct {
-		name    string
-		wantErr bool
-		in      in
+		name      string
+		choose    string
+		fileMock  stream.FileWriteReadExister
+		want      error
+		inputFlag []string
 	}{
 		{
-			name:    "success when metrics file dont exist",
-			wantErr: false,
-			in: in{
-				file: sMocks.FileWriteReadExisterCustomMock{
-					ExistsMock: func(path string) bool {
-						return false
-					},
-					ReadMock: func(path string) ([]byte, error) {
-						return []byte("some data"), nil
-					},
-					WriteMock: func(path string, content []byte) error {
-						return nil
-					},
-				},
-				input: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "yes", nil
-					},
-				},
-			},
+			name: "test run prompt",
+			choose: "yes",
+			want: nil,
 		},
 		{
-			name:    "success when not accept send metrics",
-			wantErr: false,
-			in: in{
-				file: sMocks.FileWriteReadExisterCustomMock{
-					ExistsMock: func(path string) bool {
-						return false
-					},
-					ReadMock: func(path string) ([]byte, error) {
-						return []byte("some data"), nil
-					},
-					WriteMock: func(path string, content []byte) error {
-						return nil
-					},
-				},
-				input: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "no", nil
-					},
-				},
-			},
-		},
-		{
-			name:    "fail on write file when metrics file dont exist",
-			wantErr: true,
-			in: in{
-				file: sMocks.FileWriteReadExisterCustomMock{
-					ExistsMock: func(path string) bool {
-						return false
-					},
-					ReadMock: func(path string) ([]byte, error) {
-						return []byte("some data"), nil
-					},
-					WriteMock: func(path string, content []byte) error {
-						return errors.New("reading file error")
-					},
-				},
-				input: inputListCustomMock{
-					list: func(name string, items []string) (string, error) {
-						return "yes", nil
-					},
-				},
-			},
-		},
-		{
-			name:    "fail on input list when metrics file dont exist",
-			wantErr: true,
-			in: in{
-				file: sMocks.FileWriteReadExisterCustomMock{
-					ExistsMock: func(path string) bool {
-						return false
-					},
-					ReadMock: func(path string) ([]byte, error) {
-						return []byte("some data"), nil
-					},
-					WriteMock: func(path string, content []byte) error {
-						return nil
-					},
-				},
-				input: inputListErrorMock{},
-			},
+			name:      "test run flag",
+			inputFlag: []string{"--metrics=yes"},
+			want: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metricsCmd := NewMetricsCmd(tt.in.file, tt.in.input)
-			if err := metricsCmd.Execute(); (err != nil) != tt.wantErr {
-				t.Errorf("metrics command error = %v | error wanted: %v", err, tt.wantErr)
+			inputListMock := new(mocks.InputListMock)
+			inputListMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(tt.choose, tt.want)
+
+			newMetrics := metricsCmd{
+				file:  tt.fileMock,
+				input: inputListMock,
 			}
+
+			metricsCmd := NewMetricsCmd(tt.fileMock, inputListMock)
+			metricsCmd.ParseFlags(tt.inputFlag)
+
+			got, err := newMetrics.resolveInput(metricsCmd)
+			fmt.Println(got, err)
 		})
 	}
+}
+
+func Test_RunPrompt(t *testing.T) {
+	var runPromptCases = []struct {
+		fileMock  stream.FileWriteReadExister
+		inputMock prompt.InputList
+		name      string
+		choose    string
+		want      error
+	}{
+		{
+			name:   "success with yes",
+			choose: "yes",
+			want:   nil,
+		},
+		{
+			name:   "fail on choose with yes",
+			choose: "yes",
+			want:   errors.New("error on choose"),
+		},
+	}
+	for _, tt := range runPromptCases {
+		t.Run(tt.name, func(t *testing.T) {
+			inputListMock := new(mocks.InputListMock)
+			inputListMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(tt.choose, tt.want)
+
+			newMetrics := metricsCmd{
+				file:  tt.fileMock,
+				input: inputListMock,
+			}
+
+			_, err := newMetrics.runPrompt()
+
+			assert.Equal(t, tt.want, err)
+
+		})
+	}
+
 }
 
 func Test_RunFlag(t *testing.T) {


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
Flags support for the `metrics` command
### How to verify it
`rit metrics --metrics="yes"`
### Changelog
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3137125646/artifacts/72011145)** Unzip to some folder like: `C:\home\user\downloads\pr973` Access the folder: `cd C:\home\user\downloads\pr973` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3137125646/artifacts/72011143)** Unzip to some folder like: `/home/user/downloads/pr973` Access the folder: `cd /home/user/downloads/pr973` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3137125646/artifacts/72011144)** Unzip to some folder like: `/home/user/downloads/pr973` Access the folder: `cd /home/user/downloads/pr973` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Thu Jul 01 2021 18:42:10 GMT+0000 (Coordinated Universal Time)