### PR TITLE
fix: fix check for add workspace when error different than expected

### DIFF
--- a/pkg/cmd/create_formula.go
+++ b/pkg/cmd/create_formula.go
@@ -262,12 +262,11 @@ func (c createFormulaCmd) runPrompt() (formula.Create, error) {
 				return formula.Create{}, err
 			}
 		}
-	} else {
+	} else if err != nil {
 		return formula.Create{}, err
 	}
 
 	formulaPath := formulaPath(wspace.Dir, formulaCmd)
-
 	cf := formula.Create{
 		FormulaCmd:  formulaCmd,
 		Lang:        lang,
@@ -276,8 +275,8 @@ func (c createFormulaCmd) runPrompt() (formula.Create, error) {
 	}
 
 	check := c.tree.Check()
-
 	printConflictingCommandsWarning(check)
+
 	return cf, err
 }
 

--- a/pkg/cmd/create_formula_test.go
+++ b/pkg/cmd/create_formula_test.go
@@ -210,6 +210,13 @@ func TestCreateFormulaCmd(t *testing.T) {
 			want:       errors.New("language not found"),
 			inputFlags: []string{"--name=rit test test", "--language=invalidLanguage", "--workspace=Default"},
 		},
+		{
+			name: "err empty formula command",
+			in: in{
+				inputTextVal: "",
+			},
+			want: errors.New("this input must not be empty"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description
As it does not contain an error check, an error occurred when creating a formula and selecting its workspace, since the existing validation returned an empty structure.

Thus, a check was added for when the error in adding the workspace is different than expected.

### How to verify it
Create a formula and check that no error occurs.

### Changelog
Fixes workspace addition checks when creating formula when error different than expected.
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3113198946/artifacts/71262156)** Unzip to some folder like: `C:\home\user\downloads\pr974` Access the folder: `cd C:\home\user\downloads\pr974` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3113198946/artifacts/71262154)** Unzip to some folder like: `/home/user/downloads/pr974` Access the folder: `cd /home/user/downloads/pr974` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3113198946/artifacts/71262155)** Unzip to some folder like: `/home/user/downloads/pr974` Access the folder: `cd /home/user/downloads/pr974` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Tue Jun 29 2021 12:47:06 GMT+0000 (Coordinated Universal Time)