### PR TITLE
Update doc release workflow with `create-other-repo-branch-action`

### DIFF
--- a/.github/workflows/generate-doc-release-branch.yml
+++ b/.github/workflows/generate-doc-release-branch.yml
@@ -14,11 +14,9 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: Generate release branch on documentation
-        run: |
-          git clone https://${{ secrets.ACCESS_TOKEN }}@github.com/ZupIT/docs-ritchie.git
-          cd docs-ritchie/
-          git init
-          git checkout -b release-v${{ steps.vars.outputs.tag }}
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git push origin release-v${{ steps.vars.outputs.tag }}
+        uses: GuillaumeFalourd/create-other-repo-branch-action@main
+        with:
+          repository_owner: ZupIT
+          repository_name: docs-ritchie
+          new_branch_name: release-v${{ steps.vars.outputs.tag }}
+          access_token: ${{ secrets.ACCESS_TOKEN}}


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

### Description

- Update the [doc release workflow](https://github.com/ZupIT/ritchie-cli/blob/master/.github/workflows/generate-doc-release-branch.yml) with [this action to create branches on other repositories](https://github.com/GuillaumeFalourd/create-other-repo-branch-action). This action abstracts the logic to create branches on other repositories and also give the possibility to use a specific branch to create a new one (not necessarily the default branch).

### How to verify it

I've tested it on this workflow run using other branch names: https://github.com/GuillaumeFalourd/poc-github-actions/runs/2963113326?check_suite_focus=true

#### Execution

![Screen Shot 2021-07-01 at 10 34 28](https://user-images.githubusercontent.com/22433243/124133790-91060480-da58-11eb-9763-77d856ed4396.png)

#### Which created the `test-1.0.11` branch

![Screen Shot 2021-07-01 at 10 34 17](https://user-images.githubusercontent.com/22433243/124133806-9400f500-da58-11eb-83d9-78fe9d3cdc2c.png)

### Changelog

- Update the doc release GHA workflow with `create-other-repo-branch-action`.
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3134523983/artifacts/71927364)** Unzip to some folder like: `C:\home\user\downloads\pr984` Access the folder: `cd C:\home\user\downloads\pr984` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3134523983/artifacts/71927362)** Unzip to some folder like: `/home/user/downloads/pr984` Access the folder: `cd /home/user/downloads/pr984` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3134523983/artifacts/71927363)** Unzip to some folder like: `/home/user/downloads/pr984` Access the folder: `cd /home/user/downloads/pr984` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Thu Jul 01 2021 13:46:41 GMT+0000 (Coordinated Universal Time)