### PR TITLE
adds ZupIT.pfx file in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ Temporary Items
 settings.xml
 /change.log
 /pkg-build/
+# Remove certificate
+packaging/windows/ZupIT.pfx


### PR DESCRIPTION
Signed-off-by: Otavio Santana <otaviopolianasantana@gmail.com>

This PR adds the `ZupIT.pfx` file in the gitignore file.

The main goal is to avoid that incident [992](https://github.com/ZupIT/ritchie-cli/pull/992) repeats.


## References
* https://git-scm.com/docs/gitignore
* https://github.com/ZupIT/ritchie-cli/pull/992