### PR TITLE
Fix `rit update workspace`core command behaviour

### DIFF
--- a/pkg/formula/runner/docker/pre_run.go
+++ b/pkg/formula/runner/docker/pre_run.go
@@ -63,7 +63,7 @@ var (
 	)
 
 	dockerVersionRegexp *regexp.Regexp
-	once sync.Once
+	once                sync.Once
 )
 
 var _ formula.PreRunner = PreRunManager{}
@@ -272,7 +272,7 @@ func getDockerCmd() string {
 
 func getDockerEngineVersion() string {
 	once.Do(func() {
-		dockerVersionRegexp = regexp.MustCompile("[0-9]*\\.[0-9]*\\.[0-9]*")
+		dockerVersionRegexp = regexp.MustCompile(`[0-9]*\\.[0-9]*\\.[0-9]*`)
 	})
 
 	cmd := exec.Command(dockerLegacyBinaryName, "--version")

--- a/pkg/formula/workspace/workspace.go
+++ b/pkg/formula/workspace/workspace.go
@@ -154,13 +154,9 @@ func (m Manager) Update(workspace formula.Workspace) error {
 	workspaceLocalName := repoutil.LocalName(workspace.Name)
 	workflowRitFolderPath := filepath.Join(m.ritchieHome, formula.ReposDir, workspaceLocalName.String())
 
-	err = m.Delete(workspace)
-	if err != nil {
-		return err
-	}
+	delete(workspaces, workspace.Name)
 
-	err = m.Add(workspace)
-	if err != nil {
+	if _, err := m.local.Init(workspace.Dir, workspace.Name); err != nil {
 		return err
 	}
 

--- a/pkg/formula/workspace/workspace.go
+++ b/pkg/formula/workspace/workspace.go
@@ -153,6 +153,17 @@ func (m Manager) Update(workspace formula.Workspace) error {
 
 	workspaceLocalName := repoutil.LocalName(workspace.Name)
 	workflowRitFolderPath := filepath.Join(m.ritchieHome, formula.ReposDir, workspaceLocalName.String())
+
+	err = m.Delete(workspace)
+	if err != nil {
+		return err
+	}
+
+	err = m.Add(workspace)
+	if err != nil {
+		return err
+	}
+
 	treeData, err := m.tree.Generate(workflowRitFolderPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

### Description

The `rit update workspace` command isn't working as expected as updating the tree.json isn't enough to access new formulas available locally.

### How to verify it

Try updating a workspace after a git pull and check if you can access new formulas.

### Changelog

Fix `rit update workspace`core command behaviour
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3169887362/artifacts/73002448)** Unzip to some folder like: `C:\home\user\downloads\pr1001` Access the folder: `cd C:\home\user\downloads\pr1001` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3169887362/artifacts/73002446)** Unzip to some folder like: `/home/user/downloads/pr1001` Access the folder: `cd /home/user/downloads/pr1001` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3169887362/artifacts/73002447)** Unzip to some folder like: `/home/user/downloads/pr1001` Access the folder: `cd /home/user/downloads/pr1001` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Tue Jul 06 2021 14:30:40 GMT+0000 (Coordinated Universal Time)