### PR TITLE
Update repository url of rit init command

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
 )
 
-const CommonsRepoURL = "https://github.com/ZupIT/ritchie-formulas"
+const TemplatesRepoURL = "https://github.com/ZupIT/ritchie-templates.git"
 
 var (
 	addRepoInfo               = i18n.T("init.add.commons.repo.info")
@@ -162,7 +162,7 @@ func (in initCmd) runStdin() CommandRunnerFunc {
 			repo := formula.Repo{
 				Provider: "Github",
 				Name:     "commons",
-				Url:      CommonsRepoURL,
+				Url:      TemplatesRepoURL,
 				Priority: 0,
 			}
 
@@ -317,7 +317,7 @@ func (in *initCmd) runFlags(cmd *cobra.Command) (config.Configs, error) {
 			repo := formula.Repo{
 				Provider: "Github",
 				Name:     "commons",
-				Url:      CommonsRepoURL,
+				Url:      TemplatesRepoURL,
 				Priority: 0,
 			}
 			s := spinner.StartNew(i18n.T("init.adding.commons.repo"))
@@ -469,7 +469,7 @@ func (in initCmd) addCommonsRepo() error {
 	repo := formula.Repo{
 		Provider: "Github",
 		Name:     "commons",
-		Url:      CommonsRepoURL,
+		Url:      TemplatesRepoURL,
 		Priority: 0,
 	}
 


### PR DESCRIPTION
Signed-off-by: maurineimirandazup <maurinei.miranda@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
Update repository url of `rit init` command to the new repository of templates.
### How to verify it
Run `rit init` command
### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3453544519/artifacts/82004013)** Unzip to some folder like: `C:\home\user\downloads\pr1017` Access the folder: `cd C:\home\user\downloads\pr1017` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3453544519/artifacts/82004011)** Unzip to some folder like: `/home/user/downloads/pr1017` Access the folder: `cd /home/user/downloads/pr1017` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3453544519/artifacts/82004012)** Unzip to some folder like: `/home/user/downloads/pr1017` Access the folder: `cd /home/user/downloads/pr1017` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Tue Aug 10 2021 01:22:19 GMT+0000 (Coordinated Universal Time)