### PR TITLE
Env to change ritchie home dir

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -150,9 +150,9 @@ func UserHomeDir() string {
 
 // RitchieHomeDir returns the home dir of the ritchie
 func RitchieHomeDir() string {
-	ritchieHomeName := os.Getenv("RITCHIE_HOME_DIR")
-	if ritchieHomeName != "" {
-		return filepath.Join(UserHomeDir(), ritchieHomeName)
+	newRitchieHomeName := os.Getenv("RITCHIE_HOME_DIR")
+	if newRitchieHomeName != "" {
+		return filepath.Join(UserHomeDir(), newRitchieHomeName)
 	}
 	return filepath.Join(UserHomeDir(), ritchieHomeName)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,6 +21,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -149,6 +151,11 @@ func UserHomeDir() string {
 }
 
 // RitchieHomeDir returns the home dir of the ritchie
+var flagRitchieHomeDir = flag.String("ritchie-home-dir", ritchieHomeName, "Use to set Ritchie Home Path other than " + ritchieHomeName)
 func RitchieHomeDir() string {
+	flag.Parse()
+	if *flagRitchieHomeDir != "" {
+		return filepath.Join(UserHomeDir(), *flagRitchieHomeDir)
+	}
 	return filepath.Join(UserHomeDir(), ritchieHomeName)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,8 +21,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
-
-	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -151,11 +149,10 @@ func UserHomeDir() string {
 }
 
 // RitchieHomeDir returns the home dir of the ritchie
-var flagRitchieHomeDir = flag.String("ritchie-home-dir", ritchieHomeName, "Use to set Ritchie Home Path other than " + ritchieHomeName)
 func RitchieHomeDir() string {
-	flag.Parse()
-	if *flagRitchieHomeDir != "" {
-		return filepath.Join(UserHomeDir(), *flagRitchieHomeDir)
+	ritchieHomeName := os.Getenv("RITCHIE_HOME_DIR")
+	if ritchieHomeName != "" {
+		return filepath.Join(UserHomeDir(), ritchieHomeName)
 	}
 	return filepath.Join(UserHomeDir(), ritchieHomeName)
 }


### PR DESCRIPTION
Signed-off-by: fabianofernandeszup <fabiano.fernandes@zup.com.br>


### Description
Flag to run rit cli using another folder diferent of /.rit

### How to verify it
Run rit with env `RITCHIE_HOME_DIR` with other path name inside the user home dir.

Like: 

``` bash
export RITCHIE_HOME_DIR=.othe-folder
rit
```

### Changelog
Added RITCHIE_HOME_DIR env to change directory of ritchie configuration files


---------------------------------------------

### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows**
 Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3634524695/artifacts/88010144)**
 Unzip to some folder like: `C:\home\user\downloads\pr1022`
 Access the folder: `cd C:\home\user\downloads\pr1022`
 Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`
 

 - **Linux**
 Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3634524695/artifacts/88010142)**
 Unzip to some folder like: `/home/user/downloads/pr1022`
 Access the folder: `cd /home/user/downloads/pr1022`
 Assign execute permission to binary: `chmod +x ./rit`
 Directly call the binary: `./rit --version` or `./rit name of formula`
 

 - **MacOS**
 Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3634524695/artifacts/88010143)**
 Unzip to some folder like: `/home/user/downloads/pr1022`
 Access the folder: `cd /home/user/downloads/pr1022`
 Assign execute permission to binary: `chmod +x ./rit`
 Directly call the binary: `./rit --version` or `./rit name of formula`

> Generated at Mon Aug 30 2021 19:27:04 GMT+0000 (Coordinated Universal Time)---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3634565430/artifacts/88011275)** Unzip to some folder like: `C:\home\user\downloads\pr1022` Access the folder: `cd C:\home\user\downloads\pr1022` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3634565430/artifacts/88011273)** Unzip to some folder like: `/home/user/downloads/pr1022` Access the folder: `cd /home/user/downloads/pr1022` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3634565430/artifacts/88011274)** Unzip to some folder like: `/home/user/downloads/pr1022` Access the folder: `cd /home/user/downloads/pr1022` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Mon Aug 30 2021 19:32:05 GMT+0000 (Coordinated Universal Time)