### PR TITLE
fix to build with go 1.17

### DIFF
--- a/.github/scripts/routing.sh
+++ b/.github/scripts/routing.sh
@@ -22,7 +22,7 @@ function version {
 
 function caller {
 
-   elif expr "$1" : "metric_server" >/dev/null; then
+   if expr "$1" : "metric_server" >/dev/null; then
       version
       metric_server
    else

--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,6 @@ require (
 	golang.org/x/text v0.3.3
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/kubectl v0.18.4
 )

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ZupIT/ritchie-cli/pkg/rtutorial"
 )
 
-const TemplatesRepoURL = "https://github.com/ZupIT/ritchie-templates.git"
+const TemplatesRepoURL = "https://github.com/ZupIT/ritchie-templates"
 
 var (
 	addRepoInfo               = i18n.T("init.add.commons.repo.info")

--- a/vendor/github.com/BurntSushi/toml/session.vim
+++ b/vendor/github.com/BurntSushi/toml/session.vim
@@ -1,0 +1,1 @@
+au BufWritePost *.go silent!make tags > /dev/null 2>&1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -298,6 +298,7 @@ gopkg.in/inf.v0
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->
Small fixes to build the project with golang 1.17 .
### How to verify it

### Changelog
<!-- One line summary that describes the changes introduced in this pull request -->
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3766576685/artifacts/92625074)** Unzip to some folder like: `C:\home\user\downloads\pr1034` Access the folder: `cd C:\home\user\downloads\pr1034` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3766576685/artifacts/92625072)** Unzip to some folder like: `/home/user/downloads/pr1034` Access the folder: `cd /home/user/downloads/pr1034` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3766576685/artifacts/92625073)** Unzip to some folder like: `/home/user/downloads/pr1034` Access the folder: `cd /home/user/downloads/pr1034` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Tue Sep 14 2021 15:29:33 GMT+0000 (Coordinated Universal Time)