### PR TITLE
Update v3 URLs for version and upgrade

### DIFF
--- a/.github/scripts/routing.sh
+++ b/.github/scripts/routing.sh
@@ -17,7 +17,7 @@ function metric_server {
 }
 
 function version {
-      export RELEASE_VERSION=$(curl https://commons-repo.ritchiecli.io/stable.txt)
+      export RELEASE_VERSION=$(curl https://v3.ritchiecli.io/stable.txt)
 }
 
 function caller {

--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ Adapting an existing script to Ritchie structure allows you to run it **locally*
 #### Linux
 
 ```bash
-curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
+curl -fsSL https://v3.ritchiecli.io/install.sh | bash
 ```
 
 #### MacOS
 
 ```bash
-curl -fsSL https://commons-repo.ritchiecli.io/install.sh | bash
+curl -fsSL https://v3.ritchiecli.io/install.sh | bash
 ```
 
 #### Windows
 
-- Download the installer from [ritchiecli.msi](https://commons-repo.ritchiecli.io/latest/ritchiecli.msi)
+- Download the installer from [ritchiecli.msi](https://v3.ritchiecli.io/latest/ritchiecli.msi)
 
 - Using Winget:
 

--- a/pkg/upgrade/updater.go
+++ b/pkg/upgrade/updater.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	upgradeURLFormat = "https://commons-repo.ritchiecli.io/%s/%s/rit"
+	upgradeURLFormat = "https://v3.ritchiecli.io/%s/%s/rit"
 )
 
 type updater interface {

--- a/pkg/upgrade/url_finder_test.go
+++ b/pkg/upgrade/url_finder_test.go
@@ -61,7 +61,7 @@ func TestUpgradeUrl(t *testing.T) {
 				},
 				os: "windows",
 			},
-			want: "https://commons-repo.ritchiecli.io/1.0.0/windows/rit.exe",
+			want: "https://v3.ritchiecli.io/1.0.0/windows/rit.exe",
 		},
 		{
 			name: "Get url for when happening a error",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,7 +35,7 @@ const (
 	// stableVersionFileCache is the file name to cache stableVersion
 	stableVersionFileCache = "stable-version-cache.json"
 
-	StableVersionURL = "https://commons-repo.ritchiecli.io/stable.txt"
+	StableVersionURL = "https://v3.ritchiecli.io/stable.txt"
 )
 
 type Manager struct {


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

### Description

- `rit --version` and `rit upgrade` currently use the v2 URLs. We need to use v3 URLs.

### How to verify it

- Download the latest v3 version and execute the `rit --version` or `rit upgrade` commands to check it's still using the v3.
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/3791980344/artifacts/93530627)** Unzip to some folder like: `C:\home\user\downloads\pr1043` Access the folder: `cd C:\home\user\downloads\pr1043` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/3791980344/artifacts/93530625)** Unzip to some folder like: `/home/user/downloads/pr1043` Access the folder: `cd /home/user/downloads/pr1043` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/3791980344/artifacts/93530626)** Unzip to some folder like: `/home/user/downloads/pr1043` Access the folder: `cd /home/user/downloads/pr1043` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Thu Sep 16 2021 20:37:03 GMT+0000 (Coordinated Universal Time)