### PR TITLE
Updates CODEOWNERS to reflect the new team composition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @danilomarqueszup @kelsoncarmozinezup @guillaumefalourd fabianofernandeszup
+*       @danilomarqueszup @kelsoncarmozinezup @guillaumefalourd @fabianofernandeszup

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lucasdittrichzup @rodrigomedeirosf @fabianofernandeszup @maurineimirandazup @guillaumefalourd @zuplucas
+*       @danilomarqueszup @kelsoncarmozinezup @guillaumefalourd fabianofernandeszup


### PR DESCRIPTION
Signed-off-by: Danilo Cominotti Marques <danilo.marques@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

Description
I am changing CODEOWNERS to reflect the new team composition.

How to verify it
Just a manual check.

Changelog
Changed CODEOWNERS to reflect the new team composition.---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/4261410042/artifacts/110714137)** Unzip to some folder like: `C:\home\user\downloads\pr1058` Access the folder: `cd C:\home\user\downloads\pr1058` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/4261410042/artifacts/110714135)** Unzip to some folder like: `/home/user/downloads/pr1058` Access the folder: `cd /home/user/downloads/pr1058` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/4261410042/artifacts/110714136)** Unzip to some folder like: `/home/user/downloads/pr1058` Access the folder: `cd /home/user/downloads/pr1058` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Thu Nov 04 2021 21:37:32 GMT+0000 (Coordinated Universal Time)