### PR TITLE
Update ritchie v3 deploy workflow back

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -337,32 +337,27 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_OSCLI_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_OSCLI_PROD }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
           aws-region: sa-east-1
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_OSCLI_PROD }}
-          role-session-name: OsCliProd
-          role-duration-seconds: 3600
-          role-skip-session-tagging: true
-          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID_OSCLI_PROD }}
 
       - name: Upload files
-        run: aws s3 sync --follow-symlinks --cache-control max-age=0,no-cache,no-store,must-revalidate $GITHUB_WORKSPACE s3://$AWS_S3_BUCKET/ritchie
+        run: aws s3 sync --follow-symlinks $GITHUB_WORKSPACE s3://$AWS_S3_BUCKET
         env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_OSCLI_PROD }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_V3 }}
 
-#   unix-smoke-test:
-#     needs: publish
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Load release version
-#         run: |
-#           export RIT_VERSION=$(curl https://v3.ritchiecli.io/stable.txt)
-#           echo
-#           echo -e "\033[1;32mLatest version:\033[1;37m" $RIT_VERSION
+  unix-smoke-test:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load release version
+        run: |
+          export RIT_VERSION=$(curl https://v3.ritchiecli.io/stable.txt)
+          echo
+          echo -e "\033[1;32mLatest version:\033[1;37m" $RIT_VERSION
 
-#       - name: Install ritchie
-#         run: curl -fsSL https://v3.ritchiecli.io/install.sh | bash
+      - name: Install ritchie
+        run: curl -fsSL https://v3.ritchiecli.io/install.sh | bash
 
-#       - name: Verify Command
-#         run: rit --version | grep "$RIT_VERSION"
+      - name: Verify Command
+        run: rit --version | grep "$RIT_VERSION"


### PR DESCRIPTION
Signed-off-by: GuillaumeFalourd <guillaume.falourd@zup.com.br>

### Description

- It may not be necessary to use another s3 bucket on AWS anymore.
---------------------------------------------### This pull request generated the following artifacts.
To test the health and quality of this implementation, download the respective binary for your operating system, unzip and directly run the binary like the examples below.
- **Windows** Download the file: **[rit-windows.zip](https://github.com/ZupIT/ritchie-cli/suites/4341076821/artifacts/113829658)** Unzip to some folder like: `C:\home\user\downloads\pr1060` Access the folder: `cd C:\home\user\downloads\pr1060` Directly call the binary: `.\rit.exe --version` or `.\rit.exe name of formula`  - **Linux** Download the file: **[rit-linux.zip](https://github.com/ZupIT/ritchie-cli/suites/4341076821/artifacts/113829656)** Unzip to some folder like: `/home/user/downloads/pr1060` Access the folder: `cd /home/user/downloads/pr1060` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`  - **MacOS** Download the file: **[rit-macos.zip](https://github.com/ZupIT/ritchie-cli/suites/4341076821/artifacts/113829657)** Unzip to some folder like: `/home/user/downloads/pr1060` Access the folder: `cd /home/user/downloads/pr1060` Assign execute permission to binary: `chmod +x ./rit` Directly call the binary: `./rit --version` or `./rit name of formula`> Generated at Fri Nov 12 2021 20:54:13 GMT+0000 (Coordinated Universal Time)